### PR TITLE
Add missing redirect and refresh Sprig variables

### DIFF
--- a/src/variables/SprigVariable.php
+++ b/src/variables/SprigVariable.php
@@ -182,6 +182,28 @@ class SprigVariable
     {
         Component::pushUrl($url);
     }
+    
+    /**
+     * Redirects the browser to the URL.
+     * https://htmx.org/reference#response_headers
+     *
+     * @param string $url
+     */
+    public function redirect(string $url)
+    {
+        Component::redirect($url);
+    }
+    
+    /**
+     * Refreshes the browser.
+     * https://htmx.org/reference#response_headers
+     *
+     * @param bool $refresh
+     */
+    public function refresh(bool $refresh = true)
+    {
+        Component::refresh($refresh);
+    }
 
     /**
      * Paginates an element query.


### PR DESCRIPTION
Hello,

It appears that redirect and refresh where missing from the SprigVariable class which caused

    Neither the property "refresh" nor one of the methods "refresh()", "getrefresh()"/"isrefresh()"/"hasrefresh()" or "__call()" exist and have public access in class "putyourlightson\sprig\variables\SprigVariable".

When attempting to do

    {% do sprig.refresh(true) %}

This fixes that