### PR TITLE
Use `createObject` to create component classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Sprig
 
+## Unreleased
+### Changed
+- Component classes are now created using the `createObject` method.
+
 ## 1.3.2 - 2021-01-29
 ### Fixed
 - Fixed compatibility with Craft pre version 3.5.0 ([#91](https://github.com/putyourlightson/craft-sprig/issues/91)).

--- a/src/services/ComponentsService.php
+++ b/src/services/ComponentsService.php
@@ -165,17 +165,10 @@ class ComponentsService extends Component
             return null;
         }
 
-        $componentObject = new $componentClass();
+        $componentObject = Craft::createObject(array_merge(['class' => $componentClass], $variables));
 
         if (!($componentObject instanceof ComponentInterface)) {
             return null;
-        }
-
-        // Only populate variables that exist as properties on the class
-        foreach ($variables as $name => $value) {
-            if (property_exists($componentObject, $name)) {
-                $componentObject->$name = $value;
-            }
         }
 
         return $componentObject;

--- a/src/services/ComponentsService.php
+++ b/src/services/ComponentsService.php
@@ -8,6 +8,7 @@ namespace putyourlightson\sprig\services;
 use Craft;
 use craft\base\Component;
 use craft\base\ElementInterface;
+use craft\helpers\ArrayHelper;
 use craft\helpers\Html;
 use craft\helpers\Json;
 use craft\helpers\StringHelper;
@@ -164,6 +165,12 @@ class ComponentsService extends Component
         if (!class_exists($componentClass)) {
             return null;
         }
+
+        $reflection = new \ReflectionClass($componentClass);
+        $properties = ArrayHelper::getColumn($reflection->getProperties(\ReflectionProperty::IS_PUBLIC), 'name');
+        $variables = array_filter($variables, function($key) use ($properties) {
+            return in_array($key, $properties);
+        }, ARRAY_FILTER_USE_KEY);
 
         $componentObject = Craft::createObject(array_merge(['class' => $componentClass], $variables));
 

--- a/src/services/ComponentsService.php
+++ b/src/services/ComponentsService.php
@@ -166,13 +166,10 @@ class ComponentsService extends Component
             return null;
         }
 
-        $reflection = new \ReflectionClass($componentClass);
-        $properties = ArrayHelper::getColumn($reflection->getProperties(\ReflectionProperty::IS_PUBLIC), 'name');
-        $variables = array_filter($variables, function($key) use ($properties) {
-            return in_array($key, $properties);
-        }, ARRAY_FILTER_USE_KEY);
-
-        $componentObject = Craft::createObject(array_merge(['class' => $componentClass], $variables));
+        $componentObject = Craft::createObject([
+            'class' => $componentClass,
+            'attributes' => $variables,
+        ]);
 
         if (!($componentObject instanceof ComponentInterface)) {
             return null;


### PR DESCRIPTION
Changing the way that component classes are created/instantiated. 

Using the `createObject` method has a few benefits.

- Easier to mock when creating tests.
- Yii handles the setting of properties via the `configure` method.
- You are able to use the `init` method in your component and the properties will already be set.

It was point 3 that started me on this path. I was creating a custom PHP sprig component and needed the class properties on init for some functionality. In the current implementation, this wasn't possible.

However, with this PR I now have access to my populated properties if I do the following.

```twig
{{ sprig('ExampleComponent', { foo: 'bar' }, { id: 'example-component' } }}
```

```PHP
class ExampleComponent extends Component
{
	public $foo;

	public function init() {
		parent::init()
		
		$bar = $this->foo; // $bar == 'bar'
	}
}
```