### PR TITLE
Fix ugly accessibility focus on the Monaco editor cursor

### DIFF
--- a/src/resources/css/playground.css
+++ b/src/resources/css/playground.css
@@ -83,6 +83,12 @@
     width: 350px;
 }
 
+/*--- Fix ugly accessibility focus on the Monaco editor cursor ---*/
+
+.monaco-mouse-cursor-text:focus,
+.monaco-mouse-cursor-text:focus-visible {
+    box-shadow: none!important;
+}
 
 /*--- CodeMirror ---*/
 


### PR DESCRIPTION
Fix ugly accessibility focus on the Monaco editor cursor caused by the CSS coming from Craft's stylesheet:

```css
body:not(.reduce-focus-visibility) :focus, body.reduce-focus-visibility :focus-visible {
    box-shadow: 0 0 0 1px #127fbf, 0 0 0 3px rgb(18 127 191 / 50%);
}
```

This is an issue even if the **Always show focus rings** user preference is unchecked.

This PR changes:

<img width="584" alt="Screen Shot 2021-08-29 at 12 14 19 AM" src="https://user-images.githubusercontent.com/7570798/131238647-0582c3cd-e14f-46f7-8963-76233ddc22db.png">

To this:

<img width="584" alt="Screen Shot 2021-08-29 at 12 30 24 AM" src="https://user-images.githubusercontent.com/7570798/131238652-0e128965-6b11-4921-a89a-21285b1a4ef4.png">

Signed-off-by: Andrew Welch <andrew@nystudio107.com>