### PR TITLE
Add Craft API autocomplete & documentation to Sprig playground

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "mit",
     "require": {
         "craftcms/cms": "^3.1.19",
-        "jasny/phpdoc-parser": "dev-master as 1.0.0",
+        "phpdocumentor/reflection-docblock": "^5.2.0",
         "ivopetkov/html5-dom-document-php": "^2.2.8"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "license": "mit",
     "require": {
         "craftcms/cms": "^3.1.19",
+        "jasny/phpdoc-parser": "dev-master as 1.0.0",
         "ivopetkov/html5-dom-document-php": "^2.2.8"
     },
     "require-dev": {

--- a/src/Sprig.php
+++ b/src/Sprig.php
@@ -65,6 +65,16 @@ class Sprig extends Plugin
         $this->_registerTwigExtensions();
         $this->_registerVariables();
         $this->_registerCpRoutes();
+
+        // Handler: Plugins::EVENT_AFTER_LOAD_PLUGINS
+        Event::on(
+            Plugins::class,
+            Plugins::EVENT_AFTER_LOAD_PLUGINS,
+            function () {
+                Autocomplete::generate();
+            }
+        );
+
     }
 
     /**

--- a/src/Sprig.php
+++ b/src/Sprig.php
@@ -8,7 +8,6 @@ namespace putyourlightson\sprig;
 use Craft;
 use craft\base\Plugin;
 use craft\events\RegisterUrlRulesEvent;
-use craft\services\Plugins;
 use craft\web\twig\variables\CraftVariable;
 use craft\web\UrlManager;
 use putyourlightson\sprig\models\SettingsModel;
@@ -18,8 +17,6 @@ use putyourlightson\sprig\services\RequestService;
 use putyourlightson\sprig\twigextensions\SprigTwigExtension;
 use putyourlightson\sprig\variables\SprigVariable;
 use yii\base\Event;
-
-use putyourlightson\sprig\helpers\Autocomplete;
 
 /**
  * @property ComponentsService $components

--- a/src/Sprig.php
+++ b/src/Sprig.php
@@ -8,6 +8,7 @@ namespace putyourlightson\sprig;
 use Craft;
 use craft\base\Plugin;
 use craft\events\RegisterUrlRulesEvent;
+use craft\services\Plugins;
 use craft\web\twig\variables\CraftVariable;
 use craft\web\UrlManager;
 use putyourlightson\sprig\models\SettingsModel;
@@ -17,6 +18,8 @@ use putyourlightson\sprig\services\RequestService;
 use putyourlightson\sprig\twigextensions\SprigTwigExtension;
 use putyourlightson\sprig\variables\SprigVariable;
 use yii\base\Event;
+
+use putyourlightson\sprig\helpers\Autocomplete;
 
 /**
  * @property ComponentsService $components
@@ -62,6 +65,16 @@ class Sprig extends Plugin
         $this->_registerTwigExtensions();
         $this->_registerVariables();
         $this->_registerCpRoutes();
+
+        // Handler: Plugins::EVENT_AFTER_LOAD_PLUGINS
+        Event::on(
+            Plugins::class,
+            Plugins::EVENT_AFTER_LOAD_PLUGINS,
+            function () {
+                Autocomplete::generateInternal();
+            }
+        );
+
     }
 
     /**

--- a/src/Sprig.php
+++ b/src/Sprig.php
@@ -65,16 +65,6 @@ class Sprig extends Plugin
         $this->_registerTwigExtensions();
         $this->_registerVariables();
         $this->_registerCpRoutes();
-
-        // Handler: Plugins::EVENT_AFTER_LOAD_PLUGINS
-        Event::on(
-            Plugins::class,
-            Plugins::EVENT_AFTER_LOAD_PLUGINS,
-            function () {
-                Autocomplete::generate();
-            }
-        );
-
     }
 
     /**

--- a/src/Sprig.php
+++ b/src/Sprig.php
@@ -65,16 +65,6 @@ class Sprig extends Plugin
         $this->_registerTwigExtensions();
         $this->_registerVariables();
         $this->_registerCpRoutes();
-
-        // Handler: Plugins::EVENT_AFTER_LOAD_PLUGINS
-        Event::on(
-            Plugins::class,
-            Plugins::EVENT_AFTER_LOAD_PLUGINS,
-            function () {
-                Autocomplete::generateInternal();
-            }
-        );
-
     }
 
     /**

--- a/src/controllers/AutocompleteController.php
+++ b/src/controllers/AutocompleteController.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @copyright Copyright (c) PutYourLightsOn
+ */
+
+namespace putyourlightson\sprig\controllers;
+
+use putyourlightson\sprig\helpers\Autocomplete as AutocompleteHelper;
+
+use craft\web\Controller;
+use yii\web\Response;
+
+class AutocompleteController extends Controller
+{
+    /**
+     * @return Response
+     */
+    public function actionIndex(): Response
+    {
+        $result = AutocompleteHelper::generate();
+
+        return $this->asJson($result);
+    }
+}

--- a/src/controllers/AutocompleteController.php
+++ b/src/controllers/AutocompleteController.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Copyright (c) PutYourLightsOn
+ * @copyright Copyright (c) nystudio107, PutYourLightsOn
  */
 
 namespace putyourlightson\sprig\controllers;
@@ -10,6 +10,13 @@ use putyourlightson\sprig\helpers\Autocomplete as AutocompleteHelper;
 use craft\web\Controller;
 use yii\web\Response;
 
+/**
+ * Class AutocompleteController
+ *
+ * @author    nystudio107
+ * @package   Sprig
+ * @since     1.8.2
+ */
 class AutocompleteController extends Controller
 {
     /**

--- a/src/helpers/Autocomplete.php
+++ b/src/helpers/Autocomplete.php
@@ -102,7 +102,7 @@ class Autocomplete
                 }
             }
         }
-        
+
         return $completionList;
     }
 
@@ -229,7 +229,10 @@ class Autocomplete
                 }
                 // Figure out the type
                 if ($docblock) {
-                    $detail = $docblock->getTagsByName('var') ?? "Property";
+                    $tag = $docblock->getTagsByName('var');
+                    if ($tag && isset($tag[0])) {
+                        $detail = strval($tag[0]);
+                    }
                 }
                 if ($detail === "Property") {
                     if (preg_match('/@var\s+([^\s]+)/', $docs, $matches)) {

--- a/src/helpers/Autocomplete.php
+++ b/src/helpers/Autocomplete.php
@@ -23,9 +23,7 @@ class Autocomplete
         'Controller',
     ];
 
-    /**
-     * Faux enum, from: https://microsoft.github.io/monaco-editor/api/enums/monaco.languages.completionitemkind.html
-     */
+    // Faux enum, from: https://microsoft.github.io/monaco-editor/api/enums/monaco.languages.completionitemkind.html
     const CompletionItemKind = [
         'Class' => 5,
         'Color' => 19,

--- a/src/helpers/Autocomplete.php
+++ b/src/helpers/Autocomplete.php
@@ -102,8 +102,7 @@ class Autocomplete
                 }
             }
         }
-
-
+        
         return $completionList;
     }
 
@@ -144,7 +143,14 @@ class Autocomplete
         if ($docs) {
             $docblock = $factory->create($docs);
             if ($docblock) {
-                $docs = $docblock->getDescription()->render();
+                $summary = $docblock->getSummary();
+                if (!empty($summary)) {
+                    $docs = $summary;
+                }
+                $description = $docblock->getDescription()->render();
+                if (!empty($description)) {
+                    $docs = $description;
+                }
             }
         }
         ArrayHelper::setValue($completionList, $path, [
@@ -207,11 +213,18 @@ class Autocomplete
             if ($propertyAllowed && $reflectionProperty->isPublic()) {
                 $detail = "Property";
                 $docblock = null;
-                $docs = $reflectionClass->getDocComment();
+                $docs = $reflectionProperty->getDocComment();
                 if ($docs) {
                     $docblock = $factory->create($docs);
                     if ($docblock) {
-                        $docs = $docblock->getDescription()->render();
+                        $summary = $docblock->getSummary();
+                        if (!empty($summary)) {
+                            $docs = $summary;
+                        }
+                        $description = $docblock->getDescription()->render();
+                        if (!empty($description)) {
+                            $docs = $description;
+                        }
                     }
                 }
                 // Figure out the type
@@ -299,11 +312,18 @@ class Autocomplete
                 $type = "Method";
                 $detail = $type;
                 $docblock = null;
-                $docs = $reflectionClass->getDocComment();
+                $docs = $reflectionMethod->getDocComment();
                 if ($docs) {
                     $docblock = $factory->create($docs);
                     if ($docblock) {
-                        $docs = $docblock->getDescription()->render();
+                        $summary = $docblock->getSummary();
+                        if (!empty($summary)) {
+                            $docs = $summary;
+                        }
+                        $description = $docblock->getDescription()->render();
+                        if (!empty($description)) {
+                            $docs = $description;
+                        }
                     }
                 }
                 $thisPath = trim(implode('.', [$path, $methodName]), '.');

--- a/src/helpers/Autocomplete.php
+++ b/src/helpers/Autocomplete.php
@@ -21,6 +21,9 @@ class Autocomplete
     const EXCLUDED_PROPERTY_NAMES = [
         'controller',
         'Controller',
+        'CraftEdition',
+        'CraftSolo',
+        'CraftPro',
     ];
     const EXCLUDED_PROPERTY_REGEXES = [
         '^_',
@@ -71,32 +74,34 @@ class Autocomplete
         /* @noinspection PhpInternalEntityUsedInspection */
         $globals = Craft::$app->view->getTwig()->getGlobals();
         foreach ($globals as $key => $value) {
-            $type = gettype($value);
-            switch ($type) {
-                case 'object':
-                    self::parseObject($completionList, $key, $value, '');
-                    break;
+            if (!in_array($key, self::EXCLUDED_PROPERTY_NAMES, true)) {
+                $type = gettype($value);
+                switch ($type) {
+                    case 'object':
+                        self::parseObject($completionList, $key, $value, '');
+                        break;
 
-                case 'array':
-                case 'boolean':
-                case 'double':
-                case 'integer':
-                case 'string':
-                    $kind = self::CompletionItemKind['Variable'];
-                    $path = $key;
-                    $normalizedKey = preg_replace("/[^A-Za-z]/", '', $key);
-                    if (ctype_upper($normalizedKey)) {
-                        $kind = self::CompletionItemKind['Constant'];
-                    }
-                    ArrayHelper::setValue($completionList, $path, [
-                        self::COMPLETION_KEY => [
-                            'detail' => "{$type}: {$value}",
-                            'kind' => $kind,
-                            'label' => $key,
-                            'insertText' => $key,
-                        ]
-                    ]);
-                    break;
+                    case 'array':
+                    case 'boolean':
+                    case 'double':
+                    case 'integer':
+                    case 'string':
+                        $kind = self::CompletionItemKind['Variable'];
+                        $path = $key;
+                        $normalizedKey = preg_replace("/[^A-Za-z]/", '', $key);
+                        if (ctype_upper($normalizedKey)) {
+                            $kind = self::CompletionItemKind['Constant'];
+                        }
+                        ArrayHelper::setValue($completionList, $path, [
+                            self::COMPLETION_KEY => [
+                                'detail' => "{$value}",
+                                'kind' => $kind,
+                                'label' => $key,
+                                'insertText' => $key,
+                            ]
+                        ]);
+                        break;
+                }
             }
         }
 
@@ -148,7 +153,7 @@ class Autocomplete
         }
         ArrayHelper::setValue($completionList, $path, [
             self::COMPLETION_KEY => [
-                'detail' => "{$type}: {$className}",
+                'detail' => "{$className}",
                 'documentation' => $annotations['description'] ?? $docs,
                 'kind' => self::CompletionItemKind['Class'],
                 'label' => $name,
@@ -237,7 +242,7 @@ class Autocomplete
                                     $value = json_encode($value);
                                 }
                                 if (!empty($value)) {
-                                    $detail = "{$type}: {$value}";
+                                    $detail = "{$value}";
                                 }
                             }
                         }

--- a/src/helpers/Autocomplete.php
+++ b/src/helpers/Autocomplete.php
@@ -7,6 +7,7 @@ namespace putyourlightson\sprig\helpers;
 
 use Craft;
 
+use craft\helpers\ArrayHelper;
 use Jasny\PhpdocParser\Set\PhpDocumentor;
 use Jasny\PhpdocParser\PhpdocParser;
 use Jasny\PhpdocParser\Tag\Summery;
@@ -53,7 +54,7 @@ class Autocomplete
     /**
      * Core function that generates the autocomplete array
      */
-    public static function generateInternal()
+    public static function generate()
     {
         $completionList = [];
         // Iterate through the globals in the Twig context
@@ -72,20 +73,22 @@ class Autocomplete
                 case 'integer':
                 case 'string':
                     $kind = self::CompletionItemKind['Variable'];
+                    $path = $key;
                     $normalizedKey = preg_replace("/[^A-Za-z]/", '', $key);
                     if (ctype_upper($normalizedKey)) {
                         $kind = self::CompletionItemKind['Constant'];
                     }
-                    $completionList[] = [
+                    ArrayHelper::setValue($completionList, $path, [
                         'detail' => "{$type}: {$value}",
                         'kind' => $kind,
                         'label' => $key,
                         'insertText' => $key,
-                    ];
+                    ]);
                     break;
             }
         }
-        //Craft::dd(json_encode($completionList));
+
+        return $completionList;
     }
 
     public static function parseObject(array &$completionList, string $name, $object, string $path = '')
@@ -100,11 +103,11 @@ class Autocomplete
         self::getClassCompletion($completionList, $object, $parser, $name);
         $path .= $name.'.';
         // ServiceLocator Components
-        self::getComponentCompletion($completionList, $object, $path);
+        //self::getComponentCompletion($completionList, $object, $path);
         // Class properties
-        self::getPropertyCompletion($completionList, $object, $parser, $path);
+        //self::getPropertyCompletion($completionList, $object, $parser, $path);
         // Class methods
-        self::getMethodCompletion($completionList, $object, $parser, $path);
+        //self::getMethodCompletion($completionList, $object, $parser, $path);
     }
 
     /**
@@ -129,13 +132,14 @@ class Autocomplete
         } catch (\Throwable $e) {
             // That's okay
         }
-        $completionList[] = [
+        $path = $name;
+        ArrayHelper::setValue($completionList, $path, [
             'detail' => "{$type}: {$className}",
             'documentation' => $annotations['description'] ?? $docs,
             'kind' => self::CompletionItemKind['Class'],
             'label' => $name,
             'insertText' => $name,
-        ];
+        ]);
     }
 
     /**

--- a/src/helpers/Autocomplete.php
+++ b/src/helpers/Autocomplete.php
@@ -402,7 +402,7 @@ class Autocomplete
             'entry' => new \craft\elements\Entry(),
             'tag' => new \craft\elements\Tag(),
             // Set the nonce to a blank string, as it changes on every request
-            'nonce' => "",
+            'nonce' => '',
         ];
         if (Craft::$app->getPlugins()->getPlugin(self::COMMERCE_PLUGIN_HANDLE)) {
             $result = array_merge($result, [

--- a/src/helpers/Autocomplete.php
+++ b/src/helpers/Autocomplete.php
@@ -6,6 +6,7 @@
 namespace putyourlightson\sprig\helpers;
 
 use Craft;
+use craft\base\Element;
 use craft\helpers\ArrayHelper;
 
 use yii\base\InvalidConfigException;
@@ -146,7 +147,7 @@ class Autocomplete
         self::getPropertyCompletion($completionList, $object, $factory, $path);
         // Class methods
         self::getMethodCompletion($completionList, $object, $factory, $path);
-        // Behavior methods
+        // Behavior properties
         self::getBehaviorCompletion($completionList, $object, $factory, $path);
     }
 
@@ -222,7 +223,7 @@ class Autocomplete
      * @param DocBlockFactory $factory
      * @param string $path
      */
-    protected static function getPropertyCompletion(array &$completionList, $object, DocBlockFactory $factory, string $path)
+    protected static function getPropertyCompletion(array &$completionList, $object, DocBlockFactory $factory, string $path, $recurse = true)
     {
         try {
             $reflectionClass = new \ReflectionClass($object);
@@ -310,7 +311,7 @@ class Autocomplete
                 ]);
                 // Recurse through if this is an object
                 if (isset($object->$propertyName) && is_object($object->$propertyName)) {
-                    if (!in_array($propertyName, self::EXCLUDED_PROPERTY_NAMES, true)) {
+                    if ($recurse && !in_array($propertyName, self::EXCLUDED_PROPERTY_NAMES, true)) {
                         self::parseObject($completionList, $propertyName, $object->$propertyName, $path);
                     }
                 }
@@ -395,6 +396,22 @@ class Autocomplete
                         'sortText' => '~~' . $label,
                     ]
                 ]);
+            }
+        }
+    }
+
+    /**
+     * @param array $completionList
+     * @param $object
+     * @param DocBlockFactory $factory
+     * @param string $path
+     */
+    protected static function getBehaviorCompletion(array &$completionList, $object, DocBlockFactory $factory, string $path)
+    {
+        if ($object instanceof Element) {
+            $behaviorClass = $object->getBehavior('customFields');
+            if ($behaviorClass) {
+                self::getPropertyCompletion($completionList, $behaviorClass, $factory, $path, false);
             }
         }
     }

--- a/src/helpers/Autocomplete.php
+++ b/src/helpers/Autocomplete.php
@@ -22,6 +22,9 @@ use phpDocumentor\Reflection\DocBlockFactory;
  */
 class Autocomplete
 {
+    // Constants
+    // =========================================================================
+
     const COMMERCE_PLUGIN_HANDLE = 'commerce';
 
     const COMPLETION_KEY = '__completions';
@@ -70,6 +73,9 @@ class Autocomplete
         'Value' => 13,
         'Variable' => 4,
     ];
+
+    // Public Static Methods
+    // =========================================================================
 
     /**
      * Core function that generates the autocomplete array
@@ -140,7 +146,12 @@ class Autocomplete
         self::getPropertyCompletion($completionList, $object, $factory, $path);
         // Class methods
         self::getMethodCompletion($completionList, $object, $factory, $path);
+        // Behavior methods
+        self::getBehaviorCompletion($completionList, $object, $factory, $path);
     }
+
+    // Protected Static Methods
+    // =========================================================================
 
     /**
      * @param array $completionList
@@ -387,6 +398,9 @@ class Autocomplete
             }
         }
     }
+
+    // Private Static Methods
+    // =========================================================================
 
     /**
      * Override certain values that we always want hard-coded

--- a/src/helpers/Autocomplete.php
+++ b/src/helpers/Autocomplete.php
@@ -215,6 +215,7 @@ class Autocomplete
                 try {
                     $componentObject = $object->get($key);
                 } catch (InvalidConfigException $e) {
+                    // That's okay
                 }
                 if ($componentObject) {
                     self::parseObject($completionList, $key, $componentObject, $path);

--- a/src/helpers/Autocomplete.php
+++ b/src/helpers/Autocomplete.php
@@ -1,0 +1,279 @@
+<?php
+/**
+ * @copyright Copyright (c) PutYourLightsOn
+ */
+
+namespace putyourlightson\sprig\helpers;
+
+use Craft;
+
+use Jasny\PhpdocParser\Set\PhpDocumentor;
+use Jasny\PhpdocParser\PhpdocParser;
+use Jasny\PhpdocParser\Tag\Summery;
+
+use yii\base\InvalidConfigException;
+use yii\di\ServiceLocator;
+
+class Autocomplete
+{
+    /**
+     * Faux enum, from: https://microsoft.github.io/monaco-editor/api/enums/monaco.languages.completionitemkind.html
+     */
+    const CompletionItemKind = [
+        'Class' => 5,
+        'Color' => 19,
+        'Constant' => 14,
+        'Constructor' => 2,
+        'Customcolor' => 22,
+        'Enum' => 15,
+        'EnumMember' => 16,
+        'Event' => 10,
+        'Field' => 3,
+        'File' => 20,
+        'Folder' => 23,
+        'Function' => 1,
+        'Interface' => 7,
+        'Issue' => 26,
+        'Keyword' => 17,
+        'Method' => 0,
+        'Module' => 8,
+        'Operator' => 11,
+        'Property' => 9,
+        'Reference' => 21,
+        'Snippet' => 27,
+        'Struct' => 6,
+        'Text' => 18,
+        'TypeParameter' => 24,
+        'Unit' => 12,
+        'User' => 25,
+        'Value' => 13,
+        'Variable' => 4,
+    ];
+
+    /**
+     * Core function that generates the autocomplete array
+     */
+    public static function generateInternal()
+    {
+        $completionList = [];
+        // Iterate through the globals in the Twig context
+        /* @noinspection PhpInternalEntityUsedInspection */
+        $globals = Craft::$app->view->getTwig()->getGlobals();
+        foreach ($globals as $key => $value) {
+            $type = gettype($value);
+            switch ($type) {
+                case 'object':
+                    self::parseObject($completionList, $key, $value, '');
+                    break;
+
+                case 'array':
+                case 'boolean':
+                case 'double':
+                case 'integer':
+                case 'string':
+                    $kind = self::CompletionItemKind['Variable'];
+                    $normalizedKey = preg_replace("/[^A-Za-z]/", '', $key);
+                    if (ctype_upper($normalizedKey)) {
+                        $kind = self::CompletionItemKind['Constant'];
+                    }
+                    $completionList[] = [
+                        'detail' => "{$type}: {$value}",
+                        'kind' => $kind,
+                        'label' => $key,
+                        'insertText' => $key,
+                    ];
+                    break;
+            }
+        }
+        //Craft::dd(json_encode($completionList));
+    }
+
+    public static function parseObject(array &$completionList, string $name, $object, string $path = '')
+    {
+        // Create the docblock parser
+        $customTags = [
+            new Summery(),
+        ];
+        $tags = PhpDocumentor::tags()->with($customTags);
+        $parser = new PhpdocParser($tags);
+        // The class itself
+        self::getClassCompletion($completionList, $object, $parser, $name);
+        $path .= $name.'.';
+        // ServiceLocator Components
+        self::getComponentCompletion($completionList, $object, $path);
+        // Class properties
+        self::getPropertyCompletion($completionList, $object, $parser, $path);
+        // Class methods
+        self::getMethodCompletion($completionList, $object, $parser, $path);
+    }
+
+    /**
+     * @param array $completionList
+     * @param $object
+     * @param PhpdocParser $parser
+     * @param string $name
+     */
+    protected static function getClassCompletion(array &$completionList, $object, PhpdocParser $parser, string $name)
+    {
+        try {
+            $reflectionClass = new \ReflectionClass($object);
+        } catch (\ReflectionException $e) {
+            return;
+        }
+        // Information on the class itself
+        $className = $reflectionClass->getName();
+        $type = 'Class';
+        $docs = $reflectionClass->getDocComment();
+        try {
+            $annotations = $parser->parse($docs);
+        } catch (\Throwable $e) {
+            // That's okay
+        }
+        $completionList[] = [
+            'detail' => "{$type}: {$className}",
+            'documentation' => $annotations['description'] ?? $docs,
+            'kind' => self::CompletionItemKind['Class'],
+            'label' => $name,
+            'insertText' => $name,
+        ];
+    }
+
+    /**
+     * @param array $completionList
+     * @param $object
+     * @param $path
+     */
+    protected static function getComponentCompletion(array &$completionList, $object, $path)
+    {
+        if ($object instanceof ServiceLocator) {
+            foreach ($object->getComponents() as $key => $value) {
+                try {
+                    $componentObject = $object->get($key);
+                } catch (InvalidConfigException $e) {
+                }
+                if ($componentObject) {
+                    self::parseObject($completionList, $key, $componentObject, $path);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param array $completionList
+     * @param $object
+     * @param PhpdocParser $parser
+     * @param string $path
+     */
+    protected static function getPropertyCompletion(array &$completionList, $object, PhpdocParser $parser, string $path)
+    {
+        try {
+            $reflectionClass = new \ReflectionClass($object);
+        } catch (\ReflectionException $e) {
+            return;
+        }
+        $reflectionProperties = $reflectionClass->getProperties();
+        foreach ($reflectionProperties as $reflectionProperty) {
+            if ($reflectionProperty->isPublic()) {
+                $type = "Property";
+                $docs = $reflectionProperty->getDocComment();
+                try {
+                    $annotations = $parser->parse($docs);
+                } catch (\Throwable $e) {
+                    // That's okay
+                }
+                // Figure out the type
+                $detail = $annotations['var']['type'] ?? "Property";
+                if ($detail === "Property") {
+                    if (preg_match('/@var\s+([^\s]+)/', $docs, $matches)) {
+                        list(, $type) = $matches;
+                        $detail = $type;
+                    } else {
+                        $detail = "Property";
+                    }
+                }
+                if ($detail === "Property") {
+                    if ((PHP_MAJOR_VERSION >= 7 && PHP_MINOR_VERSION >= 4) || (PHP_MAJOR_VERSION >= 8)) {
+                        if ($reflectionProperty->hasType()) {
+                            $reflectionType = $reflectionProperty->getType();
+                            if ($reflectionType && $reflectionType instanceof \ReflectionNamedType) {
+                                $type = $reflectionType::getName();
+                                $detail = $type;
+                            }
+                        }
+                        if (PHP_MAJOR_VERSION >= 8) {
+                            if ($reflectionProperty->hasDefaultValue()) {
+                                $value = $reflectionProperty->getDefaultValue();
+                                if (is_array($value)) {
+                                    $value = json_encode($value);
+                                }
+                                if (!empty($value)) {
+                                    $detail = "{$type}: {$value}";
+                                }
+                            }
+                        }
+                    }
+                }
+                $propertyName = $reflectionProperty->getName();
+                $label = $path . $propertyName;
+                $varDescription = $annotations['var']['description'] ?? null;
+                if ($varDescription) {
+                    $varDescription = str_replace(['*/', ' * '], '', $varDescription);
+                }
+                $completionList[] = [
+                    'detail' => $detail,
+                    'documentation' => $varDescription ?? $annotations['description'] ?? $docs,
+                    'kind' => self::CompletionItemKind['Property'],
+                    'label' => $label,
+                    'insertText' => $label,
+                    'sortText' => '_'.$label,
+                ];
+                // Recurse through if this is an object
+                if (isset($object->$propertyName) && is_object($object->$propertyName)) {
+                    self::parseObject($completionList, $propertyName, $object->$propertyName, $path);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param array $completionList
+     * @param $object
+     * @param PhpdocParser $parser
+     * @param string $path
+     */
+    protected static function getMethodCompletion(array &$completionList, $object, PhpdocParser $parser, string $path)
+    {
+        try {
+            $reflectionClass = new \ReflectionClass($object);
+        } catch (\ReflectionException $e) {
+            return;
+        }
+        $reflectionMethods = $reflectionClass->getMethods();
+        foreach ($reflectionMethods as $reflectionMethod) {
+            $methodName = $reflectionMethod->getName();
+            if ($methodName[0] !== '_' && $reflectionMethod->isPublic()) {
+                $type = "Method";
+                $detail = $type;
+                $docs = $reflectionMethod->getDocComment();
+                try {
+                    $annotations = $parser->parse($docs);
+                } catch (\Throwable $e) {
+                    // That's okay
+                }
+                $label = $path . $methodName . '()';
+                $varDescription = $annotations['var']['description'] ?? null;
+                if ($varDescription) {
+                    $varDescription = str_replace(['*/', ' * '], '', $varDescription);
+                }
+                $completionList[] = [
+                    'detail' => $detail,
+                    'documentation' => $varDescription ?? $annotations['description'] ?? $docs,
+                    'kind' => self::CompletionItemKind['Method'],
+                    'label' => $label,
+                    'insertText' => $label,
+                    'sortText' => '__'.$label,
+                ];
+            }
+        }
+    }
+}

--- a/src/helpers/Autocomplete.php
+++ b/src/helpers/Autocomplete.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @copyright Copyright (c) PutYourLightsOn
+ * @copyright Copyright (c) nystudio107, PutYourLightsOn
  */
 
 namespace putyourlightson\sprig\helpers;
@@ -13,6 +13,13 @@ use yii\di\ServiceLocator;
 
 use phpDocumentor\Reflection\DocBlockFactory;
 
+/**
+ * Class Autocomplete
+ *
+ * @author    nystudio107
+ * @package   Sprig
+ * @since     1.8.2
+ */
 class Autocomplete
 {
     const COMPLETION_KEY = '__completions';
@@ -106,6 +113,14 @@ class Autocomplete
         return $completionList;
     }
 
+    /**
+     * Parse the object passed in, including any properties or methods
+     *
+     * @param array $completionList
+     * @param string $name
+     * @param $object
+     * @param string $path
+     */
     public static function parseObject(array &$completionList, string $name, $object, string $path = '')
     {
         // Create the docblock factory
@@ -216,6 +231,7 @@ class Autocomplete
                 $docs = $reflectionProperty->getDocComment();
                 if ($docs) {
                     $docblock = $factory->create($docs);
+                    $docs = '';
                     if ($docblock) {
                         $summary = $docblock->getSummary();
                         if (!empty($summary)) {

--- a/src/helpers/Autocomplete.php
+++ b/src/helpers/Autocomplete.php
@@ -218,8 +218,8 @@ class Autocomplete
             $propertyName = $reflectionProperty->getName();
             // Exclude some properties
             $propertyAllowed = true;
-            foreach(self::EXCLUDED_PROPERTY_REGEXES as $excludePattern) {
-                $pattern = '`'.$excludePattern.'`i';
+            foreach (self::EXCLUDED_PROPERTY_REGEXES as $excludePattern) {
+                $pattern = '`' . $excludePattern . '`i';
                 if (preg_match($pattern, $propertyName) === 1) {
                     $propertyAllowed = false;
                 }
@@ -320,8 +320,8 @@ class Autocomplete
             $methodName = $reflectionMethod->getName();
             // Exclude some properties
             $methodAllowed = true;
-            foreach(self::EXCLUDED_METHOD_REGEXES as $excludePattern) {
-                $pattern = '`'.$excludePattern.'`i';
+            foreach (self::EXCLUDED_METHOD_REGEXES as $excludePattern) {
+                $pattern = '`' . $excludePattern . '`i';
                 if (preg_match($pattern, $methodName) === 1) {
                     $methodAllowed = false;
                 }
@@ -347,11 +347,11 @@ class Autocomplete
                 $detail = $methodName . '(';
                 $params = $reflectionMethod->getParameters();
                 $paramList = [];
-                foreach($params as $param) {
+                foreach ($params as $param) {
                     if ($param->hasType()) {
-                        $paramList[] = $param->getType()->getName() . ': ' . $param->getName();
+                        $paramList[] = $param->getType()->getName() . ': ' . '$' . $param->getName();
                     } else {
-                        $paramList[] = $param->getName();
+                        $paramList[] = '$' . $param->getName();
                     }
                 }
                 $detail .= implode(', ', $paramList) . ')';
@@ -363,7 +363,7 @@ class Autocomplete
                     $tags = $docblock->getTagsByName('param');
                     if ($tags) {
                         $docsPreamble = "Parameters:\n\n";
-                        foreach($tags as $tag) {
+                        foreach ($tags as $tag) {
                             $docsPreamble .= strval($tag) . "\n";
                         }
                         $docsPreamble .= "\n";

--- a/src/resources/js/autocomplete.js
+++ b/src/resources/js/autocomplete.js
@@ -77,10 +77,12 @@ function addCompletionItemsToMonaco(completionItems) {
             }
             // Get all the child properties
             for (let item in currentItems) {
-                console.log(item);
                 if (currentItems.hasOwnProperty(item) && !item.startsWith("__")) {
-                    // Add to final results
-                    result.push(currentItems[item][COMPLETION_KEY]);
+                    const completionItem = currentItems[item][COMPLETION_KEY];
+                    if (completionItem !== undefined) {
+                        // Add to final results
+                        result.push(completionItem);
+                    }
                 }
             }
 

--- a/src/resources/js/autocomplete.js
+++ b/src/resources/js/autocomplete.js
@@ -54,7 +54,7 @@ function addCompletionItemsToMonaco(completionItems) {
     monaco.languages.registerCompletionItemProvider('twig', {
         triggerCharacters: ['.', '('],
         provideCompletionItems: function(model, position, token) {
-            var result = [];
+            let result = [];
             // Get the last word the user has typed
             const currentLine = model.getValueInRange({startLineNumber: position.lineNumber, startColumn: 0, endLineNumber: position.lineNumber, endColumn: position.column});
             const currentWords = currentLine.replace("\t", "").split(" ");
@@ -64,10 +64,10 @@ function addCompletionItemsToMonaco(completionItems) {
             // If the last character typed is a period, then we need to look up a sub-property of the completionItems
             if (isSubProperty) {
                 // Is a sub-property, get a list of parent properties
-                var parents = currentWord.substring(0, currentWord.length - 1).split(".");
+                const parents = currentWord.substring(0, currentWord.length - 1).split(".");
                 currentItems = completionItems[parents[0]];
                 // Loop through all the parents to traverse the completion items and find the current one
-                for (var i = 1; i < parents.length; i++) {
+                for (let i = 1; i < parents.length; i++) {
                     if (currentItems.hasOwnProperty(parents[i])) {
                         currentItems = currentItems[parents[i]];
                     } else {
@@ -105,7 +105,7 @@ function addHoverHandlerToMonaco(completionItems) {
             let searchLine = currentLine.substring(0, currentWord.endColumn -1)
             let isSubProperty = false;
             let currentItems = completionItems;
-            for (var i = searchLine.length; i >= 0; i--) {
+            for (let i = searchLine.length; i >= 0; i--) {
                 if (searchLine[i] === ' ') {
                     searchLine = currentLine.substring(i + 1, searchLine.length);
                     break;
@@ -116,9 +116,9 @@ function addHoverHandlerToMonaco(completionItems) {
             }
             if (isSubProperty) {
                 // Is a sub-property, get a list of parent properties
-                var parents = searchLine.substring(0, searchLine.length).split(".");
+                const parents = searchLine.substring(0, searchLine.length).split(".");
                 // Loop through all the parents to traverse the completion items and find the current one
-                for (var i = 0; i < parents.length - 1; i++) {
+                for (let i = 0; i < parents.length - 1; i++) {
                     if (currentItems.hasOwnProperty(parents[i])) {
                         currentItems = currentItems[parents[i]];
                     } else {
@@ -149,7 +149,7 @@ function addHoverHandlerToMonaco(completionItems) {
  */
 function getCompletionItemsFromEndpoint() {
     // Try to get the completion items from local storage
-    var completionItems = getWithExpiry(AUTOCOMPLETE_CACHE_KEY);
+    let completionItems = getWithExpiry(AUTOCOMPLETE_CACHE_KEY);
     if (completionItems !== null) {
         addCompletionItemsToMonaco(completionItems);
         addHoverHandlerToMonaco(completionItems);

--- a/src/resources/js/autocomplete.js
+++ b/src/resources/js/autocomplete.js
@@ -12,16 +12,6 @@ const AUTOCOMPLETE_CACHE_KEY = 'sprig-autocomplete-cache';
 const AUTOCOMPLETE_CACHE_DURATION = 60 * 1000;
 
 /**
- * Get the last item from the array
- *
- * @param arr
- * @returns {*}
- */
-function getLastItem(arr) {
-    return arr[arr.length - 1];
-}
-
-/**
  * Store a value in local storage via a key, and with a duration in TTL
  *
  * @param key
@@ -40,7 +30,7 @@ function setWithExpiry(key, value, ttl) {
 }
 
 /**
- * Retireve a value from local storage
+ * Retrieve a value from local storage
  *
  * @param key
  * @returns {null|*}
@@ -77,12 +67,6 @@ function addCompletionItemsToMonaco(completionItems) {
             const currentLine = model.getValueInRange({startLineNumber: position.lineNumber, startColumn: 0, endLineNumber: position.lineNumber, endColumn: position.column});
             const currentWords = currentLine.replace("\t", "").split(" ");
             let currentWord = currentWords[currentWords.length - 1];
-            if (currentWord.includes('(')) {
-                currentWord = getLastItem(currentWord.split('('));
-            }
-            if (currentWord.includes('>')) {
-                currentWord = getLastItem(currentWord.split('>'));
-            }
             const isSubProperty = currentWord.charAt(currentWord.length - 1) == ".";
             let currentItems = completionItems;
             // If the last character typed is a period, then we need to look up a sub-property of the completionItems

--- a/src/resources/js/autocomplete.js
+++ b/src/resources/js/autocomplete.js
@@ -105,6 +105,8 @@ function addCompletionItemsToMonaco(completionItems) {
                     if (currentItems.hasOwnProperty(item) && !item.startsWith("__")) {
                         const completionItem = currentItems[item][COMPLETION_KEY];
                         if (completionItem !== undefined) {
+                            // Monaco adds a 'range' to the object, to denote where the autocomplete is triggered from,
+                            // which needs to be removed each time the autocomplete objects are re-used
                             delete completionItem.range;
                             // Add to final results
                             result.push(completionItem);

--- a/src/resources/js/autocomplete.js
+++ b/src/resources/js/autocomplete.js
@@ -1,97 +1,15 @@
-function ShowAutocompletion(obj) {
-    // Disable default autocompletion for javascript
-    monaco.languages.typescript.javascriptDefaults.setCompilerOptions({ noLib: true  });
+const COMPLETION_KEY = '__completions';
+const AUTOCOMPLETE_CONTROLLER_ENDPOINT = 'sprig/autocomplete/index';
+const AUTOCOMPLETE_CACHE_KEY = 'sprig-autocomplete-cache';
+const AUTOCOMPLETE_CACHE_DURATION = 60 * 1000;
 
-    // Helper function to return the monaco completion item type of a thing
-    function getType(thing, isMember) {
-        isMember =  (isMember == undefined) ? (typeof isMember == "boolean") ? isMember : false : false; // Give isMember a default value of false
-
-        switch ((typeof thing).toLowerCase()) {
-            case "object":
-                return monaco.languages.CompletionItemKind.Class;
-
-            case "function":
-                return (isMember) ? monaco.languages.CompletionItemKind.Method : monaco.languages.CompletionItemKind.Function;
-
-            default:
-                return (isMember) ? monaco.languages.CompletionItemKind.Property : monaco.languages.CompletionItemKind.Variable;
-        }
-    }
-
-    // Register object that will return autocomplete items
-    monaco.languages.registerCompletionItemProvider('twig', {
-        // Run this function when the period or open parenthesis is typed (and anything after a space)
-        triggerCharacters: ['.', '('],
-
-        // Function to generate autocompletion results
-        provideCompletionItems: function(model, position, token) {
-            // Split everything the user has typed on the current line up at each space, and only look at the last word
-            var last_chars = model.getValueInRange({startLineNumber: position.lineNumber, startColumn: 0, endLineNumber: position.lineNumber, endColumn: position.column});
-            var words = last_chars.replace("\t", "").split(" ");
-            var active_typing = words[words.length - 1]; // What the user is currently typing (everything after the last space)
-
-            // If the last character typed is a period then we need to look at member objects of the obj object
-            var is_member = active_typing.charAt(active_typing.length - 1) == ".";
-
-            // Array of autocompletion results
-            var result = [];
-
-            // Used for generic handling between member and non-member objects
-            var last_token = obj;
-            var prefix = '';
-
-            if (is_member) {
-                // Is a member, get a list of all members, and the prefix
-                var parents = active_typing.substring(0, active_typing.length - 1).split(".");
-                last_token = obj[parents[0]];
-                prefix = parents[0];
-
-                // Loop through all the parents the current one will have (to generate prefix)
-                for (var i = 1; i < parents.length; i++) {
-                    if (last_token.hasOwnProperty(parents[i])) {
-                        prefix += '.' + parents[i];
-                        last_token = last_token[parents[i]];
-                    } else {
-                        // Not valid
-                        return result;
-                    }
-                }
-
-                prefix += '.';
-            }
-            // Get all the child properties of the last token
-            for (var prop in last_token) {
-                // Do not show properites that begin with "__"
-                if (last_token.hasOwnProperty(prop) && !prop.startsWith("__")) {
-                    // Get the detail type (try-catch) incase object does not have prototype
-                    var details = '';
-                    try {
-                        details = last_token[prop].__proto__.constructor.name;
-                    } catch (e) {
-                        details = typeof last_token[prop];
-                    }
-
-                    // Create completion object
-                    var to_push = last_token[prop].__completions;
-
-                    // Change insertText and documentation for functions
-                    if (to_push.detail.toLowerCase() == 'function') {
-                        to_push.insertText += "(";
-                        to_push.documentation = (last_token[prop].toString()).split("{")[0]; // Show function prototype in the documentation popup
-                    }
-
-                    // Add to final results
-                    result.push(to_push);
-                }
-            }
-
-            return {
-                suggestions: result
-            };
-        }
-    });
-}
-
+/**
+ * Store a value in local storage via a key, and with a duration in TTL
+ *
+ * @param key
+ * @param value
+ * @param ttl
+ */
 function setWithExpiry(key, value, ttl) {
     const now = new Date()
     // `item` is an object which contains the original value
@@ -103,6 +21,12 @@ function setWithExpiry(key, value, ttl) {
     localStorage.setItem(key, JSON.stringify(item))
 }
 
+/**
+ * Retireve a value from local storage
+ *
+ * @param key
+ * @returns {null|*}
+ */
 function getWithExpiry(key) {
     const itemStr = localStorage.getItem(key)
     // if the item doesn't exist, return null
@@ -121,31 +45,77 @@ function getWithExpiry(key) {
     return item.value
 }
 
-function getCompletionItems() {
-    // Try to grab the menu from our local storage cache if possible
-    var responseVars = getWithExpiry('sprig-autocomplete-cache');
-    if (responseVars === null) {
-        // Grab the globals set Reference Tags from our controller
-        var request = new XMLHttpRequest();
-        request.open('GET', Craft.getActionUrl('sprig/autocomplete/index'), true);
-        console.log('request.open');
-        request.onload = function () {
-            if (request.status >= 200 && request.status < 400) {
-                console.log('status returned');
-                responseVars = JSON.parse(request.responseText);
-                console.log('JSON parsed');
-                setWithExpiry('sprig-autocomplete-cache', responseVars, 1);
-                console.log('stored in local storage');
-                ShowAutocompletion(responseVars);
-                console.log('autocomplete shown');
-            } else {
+/**
+ * Register completion items with the Monaco editor, for the Twig language
+ *
+ * @param completionItems
+ */
+function addCompletionItemsToMonaco(completionItems) {
+    monaco.languages.registerCompletionItemProvider('twig', {
+        triggerCharacters: ['.', '('],
+        provideCompletionItems: function(model, position, token) {
+            var result = [];
+            // Get the last word the user has typed
+            const currentLine = model.getValueInRange({startLineNumber: position.lineNumber, startColumn: 0, endLineNumber: position.lineNumber, endColumn: position.column});
+            const currentWords = currentLine.replace("\t", "").split(" ");
+            const currentWord = currentWords[currentWords.length - 1];
+            const isSubProperty = currentWord.charAt(currentWord.length - 1) == ".";
+            let currentItems = completionItems;
+            // If the last character typed is a period, then we need to look up a sub-property of the completionItems
+            if (isSubProperty) {
+                // Is a sub-property, get a list of parent properties
+                var parents = currentWord.substring(0, currentWord.length - 1).split(".");
+                currentItems = completionItems[parents[0]];
+                // Loop through all the parents to traverse the completion items and find the current one
+                for (var i = 1; i < parents.length; i++) {
+                    if (currentItems.hasOwnProperty(parents[i])) {
+                        currentItems = currentItems[parents[i]];
+                    } else {
+                        return result;
+                    }
+                }
             }
-        };
-        request.send();
-        console.log('request.send()');
-    }
+            // Get all the child properties
+            for (let item in currentItems) {
+                console.log(item);
+                if (currentItems.hasOwnProperty(item) && !item.startsWith("__")) {
+                    // Add to final results
+                    result.push(currentItems[item][COMPLETION_KEY]);
+                }
+            }
 
-    return responseVars;
+            return {
+                suggestions: result
+            };
+        }
+    });
 }
 
-getCompletionItems();
+/**
+ * Fetch the autocompletion items from local storage, or from the endpoint if they aren't cached in local storage
+ */
+function getCompletionItemsFromEndpoint() {
+    // Try to get the completion items from local storage
+    var completionItems = getWithExpiry(AUTOCOMPLETE_CACHE_KEY);
+    if (completionItems !== null) {
+        addCompletionItemsToMonaco(completionItems);
+
+        return;
+    }
+    // Ping the controller endpoint
+    let request = new XMLHttpRequest();
+    request.open('GET', Craft.getActionUrl(AUTOCOMPLETE_CONTROLLER_ENDPOINT), true);
+    request.onload = function () {
+        if (request.status >= 200 && request.status < 400) {
+            completionItems = JSON.parse(request.responseText);
+            setWithExpiry(AUTOCOMPLETE_CACHE_KEY, completionItems, AUTOCOMPLETE_CACHE_DURATION);
+            addCompletionItemsToMonaco(completionItems);
+        } else {
+            console.log('Autocomplete endpoint failed with status ' + request.status)
+        }
+    };
+    request.send();
+}
+
+// Make it go
+getCompletionItemsFromEndpoint();

--- a/src/resources/js/autocomplete.js
+++ b/src/resources/js/autocomplete.js
@@ -27,7 +27,6 @@ function ShowAutocompletion(obj) {
         provideCompletionItems: function(model, position, token) {
             // Split everything the user has typed on the current line up at each space, and only look at the last word
             var last_chars = model.getValueInRange({startLineNumber: position.lineNumber, startColumn: 0, endLineNumber: position.lineNumber, endColumn: position.column});
-            console.log(last_chars);
             var words = last_chars.replace("\t", "").split(" ");
             var active_typing = words[words.length - 1]; // What the user is currently typing (everything after the last space)
 
@@ -73,15 +72,13 @@ function ShowAutocompletion(obj) {
                     }
 
                     // Create completion object
-                    var to_push = last_token[prop];
+                    var to_push = last_token[prop].__completions;
 
                     // Change insertText and documentation for functions
                     if (to_push.detail.toLowerCase() == 'function') {
                         to_push.insertText += "(";
                         to_push.documentation = (last_token[prop].toString()).split("{")[0]; // Show function prototype in the documentation popup
                     }
-
-                    console.log(to_push);
 
                     // Add to final results
                     result.push(to_push);
@@ -130,20 +127,25 @@ function getCompletionItems() {
     if (responseVars === null) {
         // Grab the globals set Reference Tags from our controller
         var request = new XMLHttpRequest();
-        request.open('GET', Craft.getActionUrl('sprig/autocomplete/index'), false);
+        request.open('GET', Craft.getActionUrl('sprig/autocomplete/index'), true);
+        console.log('request.open');
         request.onload = function () {
             if (request.status >= 200 && request.status < 400) {
+                console.log('status returned');
                 responseVars = JSON.parse(request.responseText);
-                setWithExpiry('sprig-autocomplete-cache', responseVars, 60 * 1000)
+                console.log('JSON parsed');
+                setWithExpiry('sprig-autocomplete-cache', responseVars, 1);
+                console.log('stored in local storage');
+                ShowAutocompletion(responseVars);
+                console.log('autocomplete shown');
             } else {
             }
         };
         request.send();
-        console.log(responseVars);
+        console.log('request.send()');
     }
 
     return responseVars;
 }
-let woof = getCompletionItems();
-console.log(woof);
-ShowAutocompletion(woof);
+
+getCompletionItems();

--- a/src/resources/js/autocomplete.js
+++ b/src/resources/js/autocomplete.js
@@ -1,3 +1,11 @@
+/**
+ * autocomplete.js
+ *
+ * @author    nystudio107
+ * @package   Sprig
+ * @since     1.8.2
+ */
+
 const COMPLETION_KEY = '__completions';
 const AUTOCOMPLETE_CONTROLLER_ENDPOINT = 'sprig/autocomplete/index';
 const AUTOCOMPLETE_CACHE_KEY = 'sprig-autocomplete-cache';
@@ -93,6 +101,11 @@ function addCompletionItemsToMonaco(completionItems) {
     });
 }
 
+/**
+ * Register hover items with the Monaco editor, for the Twig language
+ *
+ * @param completionItems
+ */
 function addHoverHandlerToMonaco(completionItems) {
     monaco.languages.registerHoverProvider('twig', {
         provideHover: function (model, position) {

--- a/src/resources/js/autocomplete.js
+++ b/src/resources/js/autocomplete.js
@@ -99,12 +99,15 @@ function addHoverHandlerToMonaco(completionItems) {
             let result = {};
             const currentLine = model.getValueInRange({startLineNumber: position.lineNumber, startColumn: 0, endLineNumber: position.lineNumber, endColumn: model.getLineMaxColumn(position.lineNumber) });
             const currentWord = model.getWordAtPosition(position);
+            if (currentWord === null) {
+                return;
+            }
             let searchLine = currentLine.substring(0, currentWord.endColumn -1)
             let isSubProperty = false;
             let currentItems = completionItems;
             for (var i = searchLine.length; i >= 0; i--) {
                 if (searchLine[i] === ' ') {
-                    searchLine = currentLine.substring(i, searchLine.length);
+                    searchLine = currentLine.substring(i + 1, searchLine.length);
                     break;
                 }
             }
@@ -114,12 +117,8 @@ function addHoverHandlerToMonaco(completionItems) {
             if (isSubProperty) {
                 // Is a sub-property, get a list of parent properties
                 var parents = searchLine.substring(0, searchLine.length).split(".");
-                console.log(parents[0]);
-                console.log(completionItems[parents[0]]);
-                currentItems = completionItems[parents[0]];
-                console.log(currentItems);
                 // Loop through all the parents to traverse the completion items and find the current one
-                for (var i = 1; i < parents.length; i++) {
+                for (var i = 0; i < parents.length - 1; i++) {
                     if (currentItems.hasOwnProperty(parents[i])) {
                         currentItems = currentItems[parents[i]];
                     } else {
@@ -127,15 +126,14 @@ function addHoverHandlerToMonaco(completionItems) {
                     }
                 }
             }
-
             if (currentItems[currentWord.word] !== undefined) {
                 const completionItem = currentItems[currentWord.word][COMPLETION_KEY];
                 if (completionItem !== undefined) {
                     return {
                         range: new monaco.Range(position.lineNumber, currentWord.startColumn, position.lineNumber, currentWord.endColum),
                         contents: [
-                            {value: completionItem.label},
-                            {value: completionItem.detail},
+                            {value: '**' + completionItem.detail + '**'},
+                            {value: completionItem.documentation},
                         ]
                     }
                 }

--- a/src/resources/js/autocomplete.js
+++ b/src/resources/js/autocomplete.js
@@ -77,6 +77,7 @@ function addCompletionItemsToMonaco(completionItems) {
             const currentLine = model.getValueInRange({startLineNumber: position.lineNumber, startColumn: 0, endLineNumber: position.lineNumber, endColumn: position.column});
             const currentWords = currentLine.replace("\t", "").split(" ");
             let currentWord = currentWords[currentWords.length - 1];
+            // If the current word includes ( or >, split on that, too, to allow the autocomplete to work in nested functions and HTML tags
             if (currentWord.includes('(')) {
                 currentWord = getLastItem(currentWord.split('('));
             }

--- a/src/resources/js/autocomplete.js
+++ b/src/resources/js/autocomplete.js
@@ -1,0 +1,149 @@
+function ShowAutocompletion(obj) {
+    // Disable default autocompletion for javascript
+    monaco.languages.typescript.javascriptDefaults.setCompilerOptions({ noLib: true  });
+
+    // Helper function to return the monaco completion item type of a thing
+    function getType(thing, isMember) {
+        isMember =  (isMember == undefined) ? (typeof isMember == "boolean") ? isMember : false : false; // Give isMember a default value of false
+
+        switch ((typeof thing).toLowerCase()) {
+            case "object":
+                return monaco.languages.CompletionItemKind.Class;
+
+            case "function":
+                return (isMember) ? monaco.languages.CompletionItemKind.Method : monaco.languages.CompletionItemKind.Function;
+
+            default:
+                return (isMember) ? monaco.languages.CompletionItemKind.Property : monaco.languages.CompletionItemKind.Variable;
+        }
+    }
+
+    // Register object that will return autocomplete items
+    monaco.languages.registerCompletionItemProvider('twig', {
+        // Run this function when the period or open parenthesis is typed (and anything after a space)
+        triggerCharacters: ['.', '('],
+
+        // Function to generate autocompletion results
+        provideCompletionItems: function(model, position, token) {
+            // Split everything the user has typed on the current line up at each space, and only look at the last word
+            var last_chars = model.getValueInRange({startLineNumber: position.lineNumber, startColumn: 0, endLineNumber: position.lineNumber, endColumn: position.column});
+            console.log(last_chars);
+            var words = last_chars.replace("\t", "").split(" ");
+            var active_typing = words[words.length - 1]; // What the user is currently typing (everything after the last space)
+
+            // If the last character typed is a period then we need to look at member objects of the obj object
+            var is_member = active_typing.charAt(active_typing.length - 1) == ".";
+
+            // Array of autocompletion results
+            var result = [];
+
+            // Used for generic handling between member and non-member objects
+            var last_token = obj;
+            var prefix = '';
+
+            if (is_member) {
+                // Is a member, get a list of all members, and the prefix
+                var parents = active_typing.substring(0, active_typing.length - 1).split(".");
+                last_token = obj[parents[0]];
+                prefix = parents[0];
+
+                // Loop through all the parents the current one will have (to generate prefix)
+                for (var i = 1; i < parents.length; i++) {
+                    if (last_token.hasOwnProperty(parents[i])) {
+                        prefix += '.' + parents[i];
+                        last_token = last_token[parents[i]];
+                    } else {
+                        // Not valid
+                        return result;
+                    }
+                }
+
+                prefix += '.';
+            }
+            // Get all the child properties of the last token
+            for (var prop in last_token) {
+                // Do not show properites that begin with "__"
+                if (last_token.hasOwnProperty(prop) && !prop.startsWith("__")) {
+                    // Get the detail type (try-catch) incase object does not have prototype
+                    var details = '';
+                    try {
+                        details = last_token[prop].__proto__.constructor.name;
+                    } catch (e) {
+                        details = typeof last_token[prop];
+                    }
+
+                    // Create completion object
+                    var to_push = last_token[prop];
+
+                    // Change insertText and documentation for functions
+                    if (to_push.detail.toLowerCase() == 'function') {
+                        to_push.insertText += "(";
+                        to_push.documentation = (last_token[prop].toString()).split("{")[0]; // Show function prototype in the documentation popup
+                    }
+
+                    console.log(to_push);
+
+                    // Add to final results
+                    result.push(to_push);
+                }
+            }
+
+            return {
+                suggestions: result
+            };
+        }
+    });
+}
+
+function setWithExpiry(key, value, ttl) {
+    const now = new Date()
+    // `item` is an object which contains the original value
+    // as well as the time when it's supposed to expire
+    const item = {
+        value: value,
+        expiry: now.getTime() + ttl,
+    }
+    localStorage.setItem(key, JSON.stringify(item))
+}
+
+function getWithExpiry(key) {
+    const itemStr = localStorage.getItem(key)
+    // if the item doesn't exist, return null
+    if (!itemStr) {
+        return null
+    }
+    const item = JSON.parse(itemStr)
+    const now = new Date()
+    // compare the expiry time of the item with the current time
+    if (now.getTime() > item.expiry) {
+        // If the item is expired, delete the item from storage
+        // and return null
+        localStorage.removeItem(key)
+        return null
+    }
+    return item.value
+}
+
+function getCompletionItems() {
+    // Try to grab the menu from our local storage cache if possible
+    var responseVars = getWithExpiry('sprig-autocomplete-cache');
+    if (responseVars === null) {
+        // Grab the globals set Reference Tags from our controller
+        var request = new XMLHttpRequest();
+        request.open('GET', Craft.getActionUrl('sprig/autocomplete/index'), false);
+        request.onload = function () {
+            if (request.status >= 200 && request.status < 400) {
+                responseVars = JSON.parse(request.responseText);
+                setWithExpiry('sprig-autocomplete-cache', responseVars, 60 * 1000)
+            } else {
+            }
+        };
+        request.send();
+        console.log(responseVars);
+    }
+
+    return responseVars;
+}
+let woof = getCompletionItems();
+console.log(woof);
+ShowAutocompletion(woof);

--- a/src/resources/js/autocomplete.js
+++ b/src/resources/js/autocomplete.js
@@ -12,6 +12,16 @@ const AUTOCOMPLETE_CACHE_KEY = 'sprig-autocomplete-cache';
 const AUTOCOMPLETE_CACHE_DURATION = 60 * 1000;
 
 /**
+ * Get the last item from the array
+ *
+ * @param arr
+ * @returns {*}
+ */
+function getLastItem(arr) {
+    return arr[arr.length - 1];
+}
+
+/**
  * Store a value in local storage via a key, and with a duration in TTL
  *
  * @param key
@@ -67,6 +77,12 @@ function addCompletionItemsToMonaco(completionItems) {
             const currentLine = model.getValueInRange({startLineNumber: position.lineNumber, startColumn: 0, endLineNumber: position.lineNumber, endColumn: position.column});
             const currentWords = currentLine.replace("\t", "").split(" ");
             let currentWord = currentWords[currentWords.length - 1];
+            if (currentWord.includes('(')) {
+                currentWord = getLastItem(currentWord.split('('));
+            }
+            if (currentWord.includes('>')) {
+                currentWord = getLastItem(currentWord.split('>'));
+            }
             const isSubProperty = currentWord.charAt(currentWord.length - 1) == ".";
             let currentItems = completionItems;
             // If the last character typed is a period, then we need to look up a sub-property of the completionItems

--- a/src/resources/js/autocomplete.js
+++ b/src/resources/js/autocomplete.js
@@ -105,6 +105,7 @@ function addCompletionItemsToMonaco(completionItems) {
                     if (currentItems.hasOwnProperty(item) && !item.startsWith("__")) {
                         const completionItem = currentItems[item][COMPLETION_KEY];
                         if (completionItem !== undefined) {
+                            delete completionItem.range;
                             // Add to final results
                             result.push(completionItem);
                         }

--- a/src/resources/js/playground.js
+++ b/src/resources/js/playground.js
@@ -31,7 +31,120 @@ $(document).ready(function()
                 enabled: false
             },
         });
+
+        function ShowAutocompletion(obj) {
+            // Disable default autocompletion for javascript
+            monaco.languages.typescript.javascriptDefaults.setCompilerOptions({ noLib: true  });
+
+            // Helper function to return the monaco completion item type of a thing
+            function getType(thing, isMember) {
+                isMember =  (isMember == undefined) ? (typeof isMember == "boolean") ? isMember : false : false; // Give isMember a default value of false
+
+                switch ((typeof thing).toLowerCase()) {
+                    case "object":
+                        return monaco.languages.CompletionItemKind.Class;
+
+                    case "function":
+                        return (isMember) ? monaco.languages.CompletionItemKind.Method : monaco.languages.CompletionItemKind.Function;
+
+                    default:
+                        return (isMember) ? monaco.languages.CompletionItemKind.Property : monaco.languages.CompletionItemKind.Variable;
+                }
+            }
+
+            // Register object that will return autocomplete items
+            monaco.languages.registerCompletionItemProvider('twig', {
+                // Run this function when the period or open parenthesis is typed (and anything after a space)
+                triggerCharacters: ['.', '('],
+
+                // Function to generate autocompletion results
+                provideCompletionItems: function(model, position, token) {
+                    // Split everything the user has typed on the current line up at each space, and only look at the last word
+                    var last_chars = model.getValueInRange({startLineNumber: position.lineNumber, startColumn: 0, endLineNumber: position.lineNumber, endColumn: position.column});
+                    var words = last_chars.replace("\t", "").split(" ");
+                    var active_typing = words[words.length - 1]; // What the user is currently typing (everything after the last space)
+
+                    // If the last character typed is a period then we need to look at member objects of the obj object
+                    var is_member = active_typing.charAt(active_typing.length - 1) == ".";
+
+                    // Array of autocompletion results
+                    var result = [];
+
+                    // Used for generic handling between member and non-member objects
+                    var last_token = obj;
+                    var prefix = '';
+
+                    if (is_member) {
+                        // Is a member, get a list of all members, and the prefix
+                        var parents = active_typing.substring(0, active_typing.length - 1).split(".");
+                        last_token = obj[parents[0]];
+                        prefix = parents[0];
+
+                        // Loop through all the parents the current one will have (to generate prefix)
+                        for (var i = 1; i < parents.length; i++) {
+                            if (last_token.hasOwnProperty(parents[i])) {
+                                prefix += '.' + parents[i];
+                                last_token = last_token[parents[i]];
+                            } else {
+                                // Not valid
+                                return result;
+                            }
+                        }
+
+                        prefix += '.';
+                    }
+
+                    // Get all the child properties of the last token
+                    for (var prop in last_token) {
+                        // Do not show properites that begin with "__"
+                        if (last_token.hasOwnProperty(prop) && !prop.startsWith("__")) {
+                            // Get the detail type (try-catch) incase object does not have prototype
+                            var details = '';
+                            try {
+                                details = last_token[prop].__proto__.constructor.name;
+                            } catch (e) {
+                                details = typeof last_token[prop];
+                            }
+
+                            // Create completion object
+                            var to_push = {
+                                label: prefix + prop,
+                                kind: getType(last_token[prop], is_member),
+                                detail: details,
+                                insertText: prop
+                            };
+
+                            // Change insertText and documentation for functions
+                            if (to_push.detail.toLowerCase() == 'function') {
+                                to_push.insertText += "(";
+                                to_push.documentation = (last_token[prop].toString()).split("{")[0]; // Show function prototype in the documentation popup
+                            }
+
+                            // Add to final results
+                            result.push(to_push);
+                        }
+                    }
+
+                    return {
+                        suggestions: result
+                    };
+                }
+            });
+        }
+
+        ShowAutocompletion({
+            Person: {
+                name: "",
+                age: 0,
+                gender: {
+                    some: "woof",
+                    furry: "moron"
+                }
+            }
+        });
+
     });
+
 
     //--- htmx ---//
 
@@ -102,6 +215,7 @@ $(document).ready(function()
     });
 });
 
+
 function getCompletionItems()
 {
     let suggestions = [
@@ -111,6 +225,8 @@ function getCompletionItems()
             kind: monaco.languages.CompletionItemKind.Function,
             sortText: '_sprig',
         },
+        {"detail":"string: English","kind":4,"label":"siteName"},{"detail":"string: http:\/\/localhost:8000\/","kind":4,"label":"siteUrl"},{"detail":"string: plugindev","kind":4,"label":"systemName"},{"detail":"boolean: 1","kind":4,"label":"devMode"},{"detail":"integer: 4","kind":14,"label":"SORT_ASC"},{"detail":"integer: 3","kind":14,"label":"SORT_DESC"},{"detail":"integer: 0","kind":14,"label":"SORT_REGULAR"},{"detail":"integer: 1","kind":14,"label":"SORT_NUMERIC"},{"detail":"integer: 2","kind":14,"label":"SORT_STRING"},{"detail":"integer: 5","kind":14,"label":"SORT_LOCALE_STRING"},{"detail":"integer: 6","kind":14,"label":"SORT_NATURAL"},{"detail":"integer: 8","kind":14,"label":"SORT_FLAG_CASE"},{"detail":"integer: 1","kind":14,"label":"POS_HEAD"},{"detail":"integer: 2","kind":14,"label":"POS_BEGIN"},{"detail":"integer: 3","kind":14,"label":"POS_END"},{"detail":"integer: 4","kind":14,"label":"POS_READY"},{"detail":"integer: 5","kind":14,"label":"POS_LOAD"},{"detail":"boolean: 1","kind":4,"label":"isInstalled"},{"detail":"string: http:\/\/localhost:8000\/login","kind":4,"label":"loginUrl"},{"detail":"string: http:\/\/localhost:8000\/logout","kind":4,"label":"logoutUrl"},
+
     ];
 
     let suggestionLabels = [
@@ -138,7 +254,7 @@ function getCompletionItems()
     ];
 
     for (let i = 0; i < suggestionLabels.length; i++) {
-        suggestions[i + 1] = {
+        suggestions[i + suggestions.length] = {
             label: suggestionLabels[i],
             insertText: suggestionLabels[i],
             kind: monaco.languages.CompletionItemKind.Field,

--- a/src/resources/js/playground.js
+++ b/src/resources/js/playground.js
@@ -114,9 +114,7 @@ function getCompletionItems()
             insertText: 'sprig',
             kind: monaco.languages.CompletionItemKind.Function,
             sortText: '_sprig',
-        },
-        {"detail":"string: English","kind":4,"label":"siteName"},{"detail":"string: http:\/\/localhost:8000\/","kind":4,"label":"siteUrl"},{"detail":"string: plugindev","kind":4,"label":"systemName"},{"detail":"boolean: 1","kind":4,"label":"devMode"},{"detail":"integer: 4","kind":14,"label":"SORT_ASC"},{"detail":"integer: 3","kind":14,"label":"SORT_DESC"},{"detail":"integer: 0","kind":14,"label":"SORT_REGULAR"},{"detail":"integer: 1","kind":14,"label":"SORT_NUMERIC"},{"detail":"integer: 2","kind":14,"label":"SORT_STRING"},{"detail":"integer: 5","kind":14,"label":"SORT_LOCALE_STRING"},{"detail":"integer: 6","kind":14,"label":"SORT_NATURAL"},{"detail":"integer: 8","kind":14,"label":"SORT_FLAG_CASE"},{"detail":"integer: 1","kind":14,"label":"POS_HEAD"},{"detail":"integer: 2","kind":14,"label":"POS_BEGIN"},{"detail":"integer: 3","kind":14,"label":"POS_END"},{"detail":"integer: 4","kind":14,"label":"POS_READY"},{"detail":"integer: 5","kind":14,"label":"POS_LOAD"},{"detail":"boolean: 1","kind":4,"label":"isInstalled"},{"detail":"string: http:\/\/localhost:8000\/login","kind":4,"label":"loginUrl"},{"detail":"string: http:\/\/localhost:8000\/logout","kind":4,"label":"logoutUrl"},
-
+        }
     ];
 
     let suggestionLabels = [
@@ -144,7 +142,7 @@ function getCompletionItems()
     ];
 
     for (let i = 0; i < suggestionLabels.length; i++) {
-        suggestions[i + suggestions.length] = {
+        suggestions[i + 1] = {
             label: suggestionLabels[i],
             insertText: suggestionLabels[i],
             kind: monaco.languages.CompletionItemKind.Field,

--- a/src/resources/js/playground.js
+++ b/src/resources/js/playground.js
@@ -19,6 +19,8 @@ $(document).ready(function()
             provideCompletionItems: getCompletionItems,
         });
 
+        import(resourcesUrl + "/js/autocomplete.js");
+
         editor = monaco.editor.create($('#editor')[0], {
             language: 'twig',
             value: $('#input').val(),
@@ -31,118 +33,6 @@ $(document).ready(function()
                 enabled: false
             },
         });
-
-        function ShowAutocompletion(obj) {
-            // Disable default autocompletion for javascript
-            monaco.languages.typescript.javascriptDefaults.setCompilerOptions({ noLib: true  });
-
-            // Helper function to return the monaco completion item type of a thing
-            function getType(thing, isMember) {
-                isMember =  (isMember == undefined) ? (typeof isMember == "boolean") ? isMember : false : false; // Give isMember a default value of false
-
-                switch ((typeof thing).toLowerCase()) {
-                    case "object":
-                        return monaco.languages.CompletionItemKind.Class;
-
-                    case "function":
-                        return (isMember) ? monaco.languages.CompletionItemKind.Method : monaco.languages.CompletionItemKind.Function;
-
-                    default:
-                        return (isMember) ? monaco.languages.CompletionItemKind.Property : monaco.languages.CompletionItemKind.Variable;
-                }
-            }
-
-            // Register object that will return autocomplete items
-            monaco.languages.registerCompletionItemProvider('twig', {
-                // Run this function when the period or open parenthesis is typed (and anything after a space)
-                triggerCharacters: ['.', '('],
-
-                // Function to generate autocompletion results
-                provideCompletionItems: function(model, position, token) {
-                    // Split everything the user has typed on the current line up at each space, and only look at the last word
-                    var last_chars = model.getValueInRange({startLineNumber: position.lineNumber, startColumn: 0, endLineNumber: position.lineNumber, endColumn: position.column});
-                    var words = last_chars.replace("\t", "").split(" ");
-                    var active_typing = words[words.length - 1]; // What the user is currently typing (everything after the last space)
-
-                    // If the last character typed is a period then we need to look at member objects of the obj object
-                    var is_member = active_typing.charAt(active_typing.length - 1) == ".";
-
-                    // Array of autocompletion results
-                    var result = [];
-
-                    // Used for generic handling between member and non-member objects
-                    var last_token = obj;
-                    var prefix = '';
-
-                    if (is_member) {
-                        // Is a member, get a list of all members, and the prefix
-                        var parents = active_typing.substring(0, active_typing.length - 1).split(".");
-                        last_token = obj[parents[0]];
-                        prefix = parents[0];
-
-                        // Loop through all the parents the current one will have (to generate prefix)
-                        for (var i = 1; i < parents.length; i++) {
-                            if (last_token.hasOwnProperty(parents[i])) {
-                                prefix += '.' + parents[i];
-                                last_token = last_token[parents[i]];
-                            } else {
-                                // Not valid
-                                return result;
-                            }
-                        }
-
-                        prefix += '.';
-                    }
-
-                    // Get all the child properties of the last token
-                    for (var prop in last_token) {
-                        // Do not show properites that begin with "__"
-                        if (last_token.hasOwnProperty(prop) && !prop.startsWith("__")) {
-                            // Get the detail type (try-catch) incase object does not have prototype
-                            var details = '';
-                            try {
-                                details = last_token[prop].__proto__.constructor.name;
-                            } catch (e) {
-                                details = typeof last_token[prop];
-                            }
-
-                            // Create completion object
-                            var to_push = {
-                                label: prefix + prop,
-                                kind: getType(last_token[prop], is_member),
-                                detail: details,
-                                insertText: prop
-                            };
-
-                            // Change insertText and documentation for functions
-                            if (to_push.detail.toLowerCase() == 'function') {
-                                to_push.insertText += "(";
-                                to_push.documentation = (last_token[prop].toString()).split("{")[0]; // Show function prototype in the documentation popup
-                            }
-
-                            // Add to final results
-                            result.push(to_push);
-                        }
-                    }
-
-                    return {
-                        suggestions: result
-                    };
-                }
-            });
-        }
-
-        ShowAutocompletion({
-            Person: {
-                name: "",
-                age: 0,
-                gender: {
-                    some: "woof",
-                    furry: "moron"
-                }
-            }
-        });
-
     });
 
 


### PR DESCRIPTION
Adds the following to the Sprig playground editor in the Craft CP:

* Autocomplete of the Craft APIs
* Autocomplete for plugin APIs
* Documentation for all APIs
* Hover targets for all APIs

Autocomplete:

<img width="1169" alt="Screen Shot 2021-09-13 at 11 53 11 PM" src="https://user-images.githubusercontent.com/7570798/133248511-40646884-99ec-4553-b13c-7e0ba473f9ec.png">

Hover:

<img width="1169" alt="Screen Shot 2021-09-13 at 11 52 36 PM" src="https://user-images.githubusercontent.com/7570798/133248513-a50e9ffd-8f73-447c-9e80-e44670614397.png">

