### PR TITLE
Fixed typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.9.1 - 2021-10-05
 ### Fixed
 - Fixed an error in the CLI due to an undefined alias in Sprig core ([#170](https://github.com/putyourlightson/craft-sprig/issues/170)).
-- 
+
 ## 1.9.0 - 2021-10-04
 > {tip} The core functionality of Sprig has been split out into the [Sprig Core](https://github.com/putyourlightson/craft-sprig-core) package.
 


### PR DESCRIPTION
Fixed a typo which is causing a weird effect in the Craft CP...

<img width="823" alt="typo@2x" src="https://user-images.githubusercontent.com/5309692/136291708-eff481bc-1bdb-4e40-afed-e424f2c09b63.png">

