### PR TITLE
Add cookbook recipes to the Sprig Playground

### DIFF
--- a/src/Sprig.php
+++ b/src/Sprig.php
@@ -66,6 +66,7 @@ class Sprig extends Plugin
             function(RegisterUrlRulesEvent $event) {
                 $event->rules['sprig'] = 'sprig/playground/index';
                 $event->rules['sprig/<id:\d+>'] = 'sprig/playground/index';
+                $event->rules['sprig/<recipeSlug:[0-9a-zA-Z\-]+>'] = 'sprig/playground/index';
             }
         );
     }

--- a/src/controllers/PlaygroundController.php
+++ b/src/controllers/PlaygroundController.php
@@ -16,17 +16,28 @@ class PlaygroundController extends Controller
      * @param int|null $id
      * @return Response
      */
-    public function actionIndex(int $id = null): Response
+    public function actionIndex(int $id = null, string $recipeSlug = null): Response
     {
         $playground = null;
-
         if ($id) {
             $playground = Sprig::$plugin->playground->get($id);
+        }
+
+        $recipe = null;
+        $recipes = Sprig::$plugin->playground->getRecipes();
+        if ($id === null && $recipeSlug === null) {
+            $recipeSlug = array_key_first($recipes);
+        }
+        if ($recipeSlug) {
+            $recipe = $recipes[$recipeSlug] ?? null;
         }
 
         return $this->renderTemplate('sprig/index', [
             'playground' => $playground,
             'allPlaygrounds' => Sprig::$plugin->playground->getAll(),
+            'recipeSlug' => $recipeSlug,
+            'recipe' => $recipe,
+            'allRecipes' => $recipes,
         ]);
     }
 

--- a/src/cookbook/basic.twig
+++ b/src/cookbook/basic.twig
@@ -1,0 +1,11 @@
+<h1>
+    Hello, {{ currentUser.friendlyName }}!
+</h1>
+
+<button sprig s-val:count="{{ count + 1 }}" class="btn submit">
+    Re-render
+</button>
+
+<p>
+    <em>Component re-rendered {{ count }} times</em>
+</p>

--- a/src/cookbook/load-more.twig
+++ b/src/cookbook/load-more.twig
@@ -1,0 +1,20 @@
+{#--- _components/load-more ---#}
+
+{# Sets a default value if not defined by the `s-val:*` attribute on the button #}
+{% set offset = offset ?? 0 %}
+
+{% set entryQuery = craft.entries.offset(offset).limit(limit) %}
+{% set entries = entryQuery.all() %}
+
+{% for entry in entries %}
+    <h2>{{ entry.title }}</h2>
+{% endfor %}
+
+{# If the total entry count is greater than the number that has been displayed #}
+{% if entryQuery.count() > offset + entries|length %}
+    {# Increments `offset` by the value of `limit` and swaps itself out on click #}
+    <button sprig s-val:offset="{{ offset + limit }}" class="btn submit"
+            s-target="this" s-swap="outerHTML">
+        Load another
+    </button>
+{% endif %}

--- a/src/cookbook/pagination.twig
+++ b/src/cookbook/pagination.twig
@@ -1,0 +1,44 @@
+{#--- _components/pagination ---#}
+
+{# Sets a default value if not defined by `s-val:*` on the clicked element #}
+{% set page = page ?? 1 %}
+
+{% set entryQuery = craft.entries.limit(limit) %}
+
+{# Paginates the entry query given the current page #}
+{% set pageInfo = sprig.paginate(entryQuery, page) %}
+{% set entries = pageInfo.pageResults %}
+
+{% for entry in entries %}
+    <h2>{{ entry.title }}</h2>
+{% endfor %}
+
+{% if entries %}
+    {% if page > 1 %}
+        {# Decrements `page` by 1 and pushes the new value into the URL on click #}
+        <button sprig s-val:page="{{ page - 1 }}" s-push-url="?page={{ page - 1 }}" class="btn">
+            Previous
+        </button>
+    {% endif %}
+    {% if page < pageInfo.totalPages %}
+        {# Increments `page` by 1 and pushes the new value into the URL on click #}
+        <button sprig s-val:page="{{ page + 1 }}" s-push-url="?page={{ page + 1 }}" class="btn">
+            Next
+        </button>
+    {% endif %}
+    <p>
+        <em>
+            Showing {{ pageInfo.first }}-{{ pageInfo.last }}
+            of {{ pageInfo.total }} entries.
+        </em><br>
+        <em>Page {{ pageInfo.currentPage }} of {{ pageInfo.totalPages }} pages.</em><br>
+        {% for i in 1..pageInfo.totalPages %}
+            {% if i == page %}
+                {{ i }}
+            {% else %}
+                {# Refreshes the component and pushes the new value into the URL #}
+                <a sprig s-val:page="{{ i }}" s-push-url="?page={{ i }}">{{ i }}</a>
+            {% endif %}
+        {% endfor %}
+    </p>
+{% endif %}

--- a/src/cookbook/polling.twig
+++ b/src/cookbook/polling.twig
@@ -1,0 +1,22 @@
+{#--- _components/polling ---#}
+
+{# Sets a default value if not defined by the `timezone` select field below #}
+{% set timezone = timezone ?? 'Europe/Vienna' %}
+
+{# Refreshes the component every 5 seconds #}
+<div sprig s-trigger="every 5s" class="btn-blue pulse">
+    <h2>The time is {{ now|time('long', timezone=timezone) }}</h2>
+</div>
+
+{# Refreshes the component with a new value for `timezone` on change #}
+<div style="display: block; margin-top: 2rem;">
+    <div class="select">
+        <select sprig name="timezone">
+            <option value="US/Pacific" {{ timezone == 'US/Pacific' ? 'selected' }}>US/Pacific</option>
+            <option value="America/Buenos_Aires" {{ timezone == 'America/Buenos_Aires' ? 'selected' }}>America/Buenos_Aires</option>
+            <option value="Europe/Vienna" {{ timezone == 'Europe/Vienna' ? 'selected' }}>Europe/Vienna</option>
+            <option value="Asia/Hong_Kong" {{ timezone == 'Asia/Hong_Kong' ? 'selected' }}>Asia/Hong_Kong</option>
+            <option value="Australia/Sydney" {{ timezone == 'Australia/Sydney' ? 'selected' }}>Australia/Sydney</option>
+        </select>
+    </div>
+</div>

--- a/src/cookbook/recipes.json
+++ b/src/cookbook/recipes.json
@@ -18,5 +18,10 @@
     "name": "Pagination",
     "component": "pagination.twig",
     "variables": "page=1&limit=1"
+  },
+  {
+    "name": "Polling",
+    "component": "polling.twig",
+    "variables": ""
   }
 ]

--- a/src/cookbook/recipes.json
+++ b/src/cookbook/recipes.json
@@ -13,5 +13,10 @@
     "name": "Load More",
     "component": "load-more.twig",
     "variables": "limit=1"
+  },
+  {
+    "name": "Pagination",
+    "component": "pagination.twig",
+    "variables": "page=1&limit=1"
   }
 ]

--- a/src/cookbook/recipes.json
+++ b/src/cookbook/recipes.json
@@ -8,5 +8,10 @@
     "name": "Search",
     "component": "search.twig",
     "variables": ""
+  },
+  {
+    "name": "Load More",
+    "component": "load-more.twig",
+    "variables": "limit=1"
   }
 ]

--- a/src/cookbook/recipes.json
+++ b/src/cookbook/recipes.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "Basic",
+    "component": "basic.twig",
+    "variables": "count=1"
+  },
+  {
+    "name": "Search",
+    "component": "search.twig",
+    "variables": ""
+  }
+]

--- a/src/cookbook/search.twig
+++ b/src/cookbook/search.twig
@@ -1,0 +1,29 @@
+{#--- _components/search ---#}
+
+{# Sets a default value if not defined by the `query` input field below #}
+{% set query = query ?? '' %}
+
+{# Replaces only the `#results` div on keyup or when the value is changed #}
+<div class="search">
+    <input sprig s-trigger="keyup changed" s-replace="#results"
+           type="text" name="query" value="{{ query }}" placeholder="Search" autocomplete="off">
+    <div class="search-icon">
+        <svg xmlns="http://www.w3.org/2000/svg" class="search-svg" viewBox="0 0 20 20"><path d="M12.9 14.32a8 8 0 1 1 1.41-1.41l5.35 5.33-1.42 1.42-5.33-5.34zM8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12z"></path></svg>
+    </div>
+</div>
+<div class="search">
+    <div id="results">
+        {% if query %}
+            {% set entries = craft.entries.search(query).all() %}
+            {% if entries|length %}
+                <div class="results" style="display: block;">
+                {% for entry in entries %}
+                    <a href="{{ entry.url }}">{{ entry.title }}</a>
+                {% endfor %}
+                </div>
+            {% else %}
+                No results
+            {% endif %}
+        {% endif %}
+    </div>
+</div>

--- a/src/models/PlaygroundModel.php
+++ b/src/models/PlaygroundModel.php
@@ -6,6 +6,7 @@
 namespace putyourlightson\sprig\plugin\models;
 
 use craft\base\Model;
+use yii\behaviors\AttributeTypecastBehavior;
 
 class PlaygroundModel extends Model
 {
@@ -28,4 +29,42 @@ class PlaygroundModel extends Model
      * @var string
      */
     public $variables;
+
+    // Public Methods
+    // =========================================================================
+
+    /**
+     * @inheritdoc
+     */
+    public function rules()
+    {
+        return array_merge(
+            parent::rules(),
+            [
+                ['id', 'integer'],
+                ['id', 'default', 'value' => null],
+                ['name', 'required'],
+                ['name', 'string'],
+                ['component', 'required'],
+                ['component', 'string'],
+                ['variables', 'string'],
+            ]
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function behaviors()
+    {
+        return array_merge(
+            parent::behaviors(),
+            [
+                'typecast' => [
+                    'class' => AttributeTypecastBehavior::class,
+                    // 'attributeTypes' will be composed automatically according to `rules()`
+                ],
+            ]
+        );
+    }
 }

--- a/src/resources/css/playground.css
+++ b/src/resources/css/playground.css
@@ -90,22 +90,3 @@
     box-shadow: none!important;
 }
 
-/*--- CodeMirror ---*/
-
-.CodeMirror {
-    height: 380px;
-    border-radius: 5px 0 0 5px;
-    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
-    font-size: 1em;
-}
-
-.CodeMirror-gutters {
-    border: none;
-    box-shadow: inset -1px 0 0 rgba(51, 64, 77, 0.1);
-    background-color: #f3f7fc;
-}
-
-.CodeMirror-linenumber {
-    padding: 0 6px 0 2px;
-    color: #9aa5b1;
-}

--- a/src/resources/css/playground.css
+++ b/src/resources/css/playground.css
@@ -233,3 +233,45 @@
     color: #909DAD;
     color: rgba(144, 157, 173, var(--text-opacity));
 }
+
+/* Polling */
+
+
+.pulse {
+    -webkit-animation: pulse 0.5s ease-in-out both;
+    animation: pulse 0.5s ease-in-out both;
+}
+
+@-webkit-keyframes pulse{
+    0%{-webkit-transform:scale(1);transform:scale(1)}50%{-webkit-transform:scale(1.1);transform:scale(1.1)}100%{-webkit-transform:scale(1);transform:scale(1)}}@keyframes pulse{0%{-webkit-transform:scale(1);transform:scale(1)}50%{-webkit-transform:scale(1.1);transform:scale(1.1)}100%{-webkit-transform:scale(1);transform:scale(1)}
+                                                                                                                                                                                    }
+
+.playground-output .btn-blue {
+    font-family: Ingeborg-HeavyItalic, serif;
+    border-radius: 0.25rem;
+    display: inline-block;
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+    text-decoration: none
+}
+
+.playground-output .btn-blue:hover {
+    text-decoration: none;
+}
+
+.playground-output .btn-blue {
+    --bg-opacity: 1;
+    background-color: #2a4365;
+    background-color: rgba(42, 67, 101, var(--bg-opacity));
+    --text-opacity: 1;
+    color: #fff;
+    color: rgba(255, 255, 255, var(--text-opacity))
+}
+
+.playground-output .btn-blue:hover {
+    --bg-opacity: 1;
+    background-color: #2c5282;
+    background-color: rgba(44, 82, 130, var(--bg-opacity));
+}

--- a/src/resources/css/playground.css
+++ b/src/resources/css/playground.css
@@ -90,3 +90,146 @@
     box-shadow: none!important;
 }
 
+/*--- Scoped CSS for the recipe output results ---*/
+
+/* Search recipe */
+
+.playground-output .search {
+    position: relative;
+    margin-top: 0.5rem;
+    margin-bottom: 1rem;
+    margin-right: 0.75rem;
+    font-size: 16px;
+}
+
+.playground-output .search input {
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+    border-width: 1px;
+    border-radius: 0.5rem;
+    --bg-opacity: 1;
+    background-color: #F6F7F9;
+    background-color: rgba(246, 247, 249, var(--bg-opacity));
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    padding-right: 1rem;
+    padding-left: 2rem;
+    width: 80%;
+}
+
+.playground-output .search .results {
+    position: absolute;
+    z-index: 50;
+    width: 100%;
+    border-width: 1px;
+    border-radius: 0.5rem;
+    margin-top: 0.25rem;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    --bg-opacity: 1;
+    background-color: #F6F7F9;
+    background-color: rgba(246, 247, 249, var(--bg-opacity));
+    --text-opacity: 1;
+    color: #454f5b;
+    color: rgba(69, 79, 91, var(--text-opacity));
+    display: none
+}
+
+.playground-output .search .results a {
+    display: block;
+    text-decoration: none;
+    border-bottom-width: 1px;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+    overflow-x: hidden
+}
+
+.search .results a:last-of-type {
+    border-style: none;
+}
+
+.playground-output .search .results a:hover {
+    --bg-opacity: 1;
+    background-color: #E7EBEF;
+    background-color: rgba(231, 235, 239, var(--bg-opacity));
+}
+
+.playground-output .search .results a div {
+    line-height: 1.0;
+    font-size: 1rem;
+    --text-opacity: 1;
+    color: #606873;
+    color: rgba(96, 104, 115, var(--text-opacity));
+}
+
+.playground-output .search .results a span {
+    --text-opacity: 1;
+    color: #CE9A25;
+    color: rgba(206, 154, 37, var(--text-opacity));
+}
+
+.playground-output .search .results:before {
+    display: block;
+    position: absolute;
+    --bg-opacity: 1;
+    border-top-style: solid;
+    border-right-style: solid;
+    border-width: 1px;
+    border-right-color: #CCC;
+    border-top-color: #CCC;
+    background-color: #F6F7F9;
+    background-color: rgba(246, 247, 249, var(--bg-opacity));
+    z-index: 50;
+    border-right-width: 1px;
+    border-top-width: 1px;
+    content: "";
+    width: 14px;
+    height: 14px;
+    top: -8px;
+    left: 12px;
+    transform: rotate(
+            -45deg);
+    border-radius: 2px;
+}
+
+.playground-output .search .results {
+    position: absolute;
+    z-index: 50;
+    width: 100%;
+    border-style: solid;
+    border-width: 1px;
+    border-color: #CCC;
+    border-radius: 0.5rem;
+    margin-top: 0.25rem;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    --bg-opacity: 1;
+    background-color: #F6F7F9;
+    background-color: rgba(246, 247, 249, var(--bg-opacity));
+    --text-opacity: 1;
+    color: #454f5b;
+    color: rgba(69, 79, 91, var(--text-opacity));
+    display: none;
+}
+
+.playground-output .search .search-icon {
+    left: 0;
+    top: 0;
+    bottom: 0;
+    position: absolute;
+    pointer-events: none;
+    padding-left: 0.75rem;
+    align-items: center;
+    display: flex;
+}
+
+.playground-output .search .search-svg {
+    width: 1rem;
+    fill: currentColor;
+    pointer-events: none;
+    --text-opacity: 1;
+    color: #909DAD;
+    color: rgba(144, 157, 173, var(--text-opacity));
+}

--- a/src/services/PlaygroundService.php
+++ b/src/services/PlaygroundService.php
@@ -17,6 +17,8 @@ use yii\helpers\Inflector;
  */
 class PlaygroundService extends Component
 {
+    const COOKBOOK_DIR_PATH = '@putyourlightson/sprig/plugin/cookbook/';
+
     /**
      * Returns a saved playground.
      *
@@ -123,7 +125,7 @@ class PlaygroundService extends Component
     public function getRecipes(): array
     {
         $recipes = [];
-        $recipesIndex = Craft::getAlias('@putyourlightson/sprig/plugin/cookbook/recipes.json');
+        $recipesIndex = Craft::getAlias(self::COOKBOOK_DIR_PATH . 'recipes.json');
         if ($recipesIndex === false) {
             return $recipes;
         }
@@ -137,7 +139,7 @@ class PlaygroundService extends Component
         }
         foreach ($recipesArray as $recipe) {
             $playground = new PlaygroundModel($recipe);
-            $recipeComponent = Craft::getAlias('@putyourlightson/sprig/plugin/cookbook/'.$playground->component);
+            $recipeComponent = Craft::getAlias(self::COOKBOOK_DIR_PATH .$playground->component);
             if ($recipeComponent === false) {
                 continue;
             }

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -19,15 +19,21 @@
 
     <div id="context-btngroup" class="btngroup">
         <button type="button" id="context-btn" class="btn menubtn">
-            <span id="revision-label">{{ playground ? playground.name : 'New' }}</span>
+            <span id="revision-label">{{ playground.name ?? recipe.name }}</span>
         </button>
         <div class="menu">
+            {% if allRecipes|length > 0 %}<h6>{{ "Example Components" | t('sprig') }}</h6>{% endif %}
             <ul class="padded">
+                {% for curSlug,curRecipe in allRecipes %}
                 <li>
-                    <a href="{{ url('sprig') }}" class="{{ playground is null ? 'sel' }}">
-                        New
+                    <a href="{{ url('sprig/' ~ curSlug) }}" class="{{ curSlug == recipeSlug ? 'sel' }}">
+                        {{ curRecipe.name }}
                     </a>
                 </li>
+                {% endfor %}
+            </ul>
+            {% if allPlaygrounds|length > 0 %}<h6>{{ "Saved Components" | t('sprig') }}</h6>{% endif %}
+            <ul class="padded">
                 {% for curPlayground in allPlaygrounds %}
                     <li>
                         <a href="{{ url('sprig/' ~ curPlayground.id) }}" class="{{ playground and playground.id == curPlayground.id ? 'sel' }}">
@@ -101,26 +107,14 @@
                     {%- if playground -%}
                         {{ playground.component }}
                     {%- else -%}
-                        {%- verbatim -%}
-<h1>
-    Hello, {{ currentUser.friendlyName }}!
-</h1>
-
-<button sprig s-val:count="{{ count + 1 }}" class="btn submit">
-    Re-render
-</button>
-
-<p>
-    <em>Component re-rendered {{ count }} times</em>
-</p>
-                        {%- endverbatim -%}
+                        {{ recipe.component }}
                     {%- endif -%}
                 </textarea>
                 <button id="create" type="submit" class="btn submit topright">{{ 'Create'|t('sprig') }}</button>
             </div>
             <div class="variables content-pane">
                 <p class="light code">{{ 'Component Variables'|t('sprig') }}</p>
-                {% set variables = playground ? playground.variables : 'count=0' %}
+                {% set variables = playground ? playground.variables : recipe.variables %}
                 <input id="input-variables" class="input code fullwidth field" value="{{ variables }}" placeholder="x=1&y=2&z=3">
             </div>
         </div>
@@ -132,7 +126,9 @@
                     <span id="spinner" class="spinner" style="display: none;"></span>
                 </p>
                 <a href="#" id="output-toggle" class="btn topright">&lt; &gt;</a>
-                {{ sprig('SprigPlayground', {}, {id: 'playground'}) }}
+                <div class="playground-output">
+                    {{ sprig('SprigPlayground', {}, {id: 'playground'}) }}
+                </div>
                 <textarea id="sourcecode" class="code fullwidth field" style="display: none;" disabled></textarea>
             </div>
             <div class="variables content-pane">

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -121,7 +121,7 @@
             <div class="variables content-pane">
                 <p class="light code">{{ 'Component Variables'|t('sprig') }}</p>
                 {% set variables = playground ? playground.variables : 'count=0' %}
-                <input id="input-variables" class="input code fullwidth field" value="{{ variables }}" placeholder="x=1,y=2,z=3">
+                <input id="input-variables" class="input code fullwidth field" value="{{ variables }}" placeholder="x=1&y=2&z=3">
             </div>
         </div>
 


### PR DESCRIPTION
Instead of just the default "New" now there can be an arbitrary number of "Cookbook Recipes" bundled in the playground. They behave just like the "New" template that was in Sprig, but allow for more examples for people to play with out of the box:

<img width="1227" alt="Screen Shot 2021-10-17 at 2 36 30 AM" src="https://user-images.githubusercontent.com/7570798/137614834-6aeabd2d-fc75-4f48-9d49-17b65e50465c.png">

I just added:

* Basic (the current "New" default)
* Search (adapted from the Sprig Cookbook search component)

I also tossed in some scoped CSS to make the output look a little nicer.

Probably the CSS could be cleaned up a good bit, and you may want to add more "out of the box" examples people can play with.