### PR TITLE
fix: Fixed an issue where the `Autocomplete` helper could throw an ex…

### DIFF
--- a/src/helpers/Autocomplete.php
+++ b/src/helpers/Autocomplete.php
@@ -12,6 +12,7 @@ use craft\helpers\ArrayHelper;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionNamedType;
+use ReflectionUnionType;
 use yii\base\Behavior;
 use yii\base\InvalidConfigException;
 use yii\di\ServiceLocator;
@@ -388,7 +389,18 @@ class Autocomplete
                 $paramList = [];
                 foreach ($params as $param) {
                     if ($param->hasType()) {
-                        $paramList[] = $param->getType()->getName() . ': ' . '$' . $param->getName();
+                        $reflectionType = $param->getType();
+                        if ($reflectionType instanceof ReflectionUnionType) {
+                            $unionTypes = $reflectionType->getTypes();
+                            $typeName = '';
+                            foreach($unionTypes as $unionType) {
+                                $typeName.='|' . $unionType->getName();
+                            }
+                            $typeName = trim($typeName, '|');
+                            $paramList[] = $typeName . ': ' . '$' . $param->getName();
+                        } else {
+                            $paramList[] = $param->getType()->getName() . ': ' . '$' . $param->getName();
+                        }
                     } else {
                         $paramList[] = '$' . $param->getName();
                     }


### PR DESCRIPTION
Fixed an issue where the `Autocomplete` helper could throw an exception if it encountered a `ReflectionUnionType`

Should also be merged into the Craft 4 version.