### PR TITLE
Fix playground overflow, no longer need to add default Autocompletes

### DIFF
--- a/src/Sprig.php
+++ b/src/Sprig.php
@@ -9,8 +9,6 @@ use craft\base\Model;
 use craft\base\Plugin;
 use craft\events\RegisterUrlRulesEvent;
 use craft\web\UrlManager;
-use nystudio107\twigfield\autocompletes\CraftApiAutocomplete;
-use nystudio107\twigfield\autocompletes\TwigLanguageAutocomplete;
 use nystudio107\twigfield\events\RegisterTwigfieldAutocompletesEvent;
 use nystudio107\twigfield\services\AutocompleteService;
 use putyourlightson\sprig\plugin\autocompletes\SprigApiAutocomplete;
@@ -84,7 +82,7 @@ class Sprig extends Plugin
     private function _registerCpRoutes()
     {
         Event::on(UrlManager::class, UrlManager::EVENT_REGISTER_CP_URL_RULES,
-            function(RegisterUrlRulesEvent $event) {
+            function (RegisterUrlRulesEvent $event) {
                 $event->rules['sprig'] = 'sprig/playground/index';
                 $event->rules['sprig/<id:\d+>'] = 'sprig/playground/index';
                 $event->rules['sprig/<slug:([^\/]*)?>'] = 'sprig/playground/index';
@@ -98,10 +96,8 @@ class Sprig extends Plugin
     private function _registerAutocompletes()
     {
         Event::on(AutocompleteService::class, AutocompleteService::EVENT_REGISTER_TWIGFIELD_AUTOCOMPLETES,
-            function(RegisterTwigfieldAutocompletesEvent $event) {
+            function (RegisterTwigfieldAutocompletesEvent $event) {
                 if ($event->fieldType === self::SPRIG_TWIG_FIELD_TYPE) {
-                    $event->types[] = TwigLanguageAutocomplete::class;
-                    $event->types[] = CraftApiAutocomplete::class;
                     $event->types[] = SprigApiAutocomplete::class;
                 }
             }

--- a/src/resources/css/playground.css
+++ b/src/resources/css/playground.css
@@ -4,7 +4,7 @@
 }
 
 .playground {
-    height: 600px;
+    height: auto;
     display: flex;
     align-items: flex-start;
 }


### PR DESCRIPTION
Fix playground overflow, no longer need to add default Autocompletes