### PR TITLE
[feat] - v4 Code Editor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "require": {
     "php": "^8.0.2",
     "craftcms/cms": "^4.0",
-    "nystudio107/craft-twigfield": "^1.0.8",
+    "nystudio107/craft-code-editor": "^1.0.0",
     "putyourlightson/craft-sprig-core": "^2.1.1"
   },
   "autoload": {

--- a/src/Sprig.php
+++ b/src/Sprig.php
@@ -9,8 +9,8 @@ use craft\base\Model;
 use craft\base\Plugin;
 use craft\events\RegisterUrlRulesEvent;
 use craft\web\UrlManager;
-use nystudio107\twigfield\events\RegisterTwigfieldAutocompletesEvent;
-use nystudio107\twigfield\services\AutocompleteService;
+use nystudio107\codeeditor\events\RegisterCodeEditorAutocompletesEvent;
+use nystudio107\codeeditor\services\AutocompleteService;
 use putyourlightson\sprig\plugin\autocompletes\SprigApiAutocomplete;
 use putyourlightson\sprig\plugin\models\SettingsModel;
 use putyourlightson\sprig\plugin\services\PlaygroundService;
@@ -23,7 +23,7 @@ use yii\base\Event;
  */
 class Sprig extends Plugin
 {
-    public const SPRIG_TWIG_FIELD_TYPE = 'SprigField';
+    public const SPRIG_CODEEDITOR_FIELD_TYPE = 'SprigField';
 
     /**
      * @var Sprig
@@ -95,9 +95,9 @@ class Sprig extends Plugin
      */
     private function _registerAutocompletes()
     {
-        Event::on(AutocompleteService::class, AutocompleteService::EVENT_REGISTER_TWIGFIELD_AUTOCOMPLETES,
-            function (RegisterTwigfieldAutocompletesEvent $event) {
-                if ($event->fieldType === self::SPRIG_TWIG_FIELD_TYPE) {
+        Event::on(AutocompleteService::class, AutocompleteService::EVENT_REGISTER_CODEEDITOR_AUTOCOMPLETES,
+            function (RegisterCodeEditorAutocompletesEvent $event) {
+                if ($event->fieldType === self::SPRIG_CODEEDITOR_FIELD_TYPE) {
                     $event->types[] = SprigApiAutocomplete::class;
                 }
             }

--- a/src/autocompletes/SprigApiAutocomplete.php
+++ b/src/autocompletes/SprigApiAutocomplete.php
@@ -6,10 +6,10 @@
 namespace putyourlightson\sprig\plugin\autocompletes;
 
 use Craft;
-use nystudio107\twigfield\base\Autocomplete;
-use nystudio107\twigfield\models\CompleteItem;
-use nystudio107\twigfield\types\AutocompleteTypes;
-use nystudio107\twigfield\types\CompleteItemKind;
+use nystudio107\codeeditor\base\Autocomplete;
+use nystudio107\codeeditor\models\CompleteItem;
+use nystudio107\codeeditor\types\AutocompleteTypes;
+use nystudio107\codeeditor\types\CompleteItemKind;
 
 class SprigApiAutocomplete extends Autocomplete
 {

--- a/src/templates/index.twig
+++ b/src/templates/index.twig
@@ -121,8 +121,6 @@
                 <p class="light code">{{ 'Component'|t('sprig') }}</p>
                 {# See default options in https://github.com/nystudio107/craft-code-editor/blob/develop/src/web/assets/src/js/default-monaco-editor-options.ts #}
                 {% set options = {
-                    language: 'javascript',
-                    theme: 'vs',
                     lineNumbers: 'on',
                     lineNumbersMinChars: 4,
                     lineDecorationsWidth: 6,

--- a/src/templates/index.twig
+++ b/src/templates/index.twig
@@ -1,6 +1,6 @@
 {% extends '_layouts/cp' %}
 
-{% import 'twigfield/twigfield' as twigfield %}
+{% import 'codeeditor/codeEditor' as codeEditor %}
 
 {% set title = 'Sprig Playground'|t('sprig') %}
 
@@ -119,14 +119,16 @@
             </div>
             <div class="pane input-pane">
                 <p class="light code">{{ 'Component'|t('sprig') }}</p>
-                {# See default options in https://github.com/nystudio107/craft-twigfield/blob/develop/src/web/assets/src/js/twigfield.js #}
+                {# See default options in https://github.com/nystudio107/craft-code-editor/blob/develop/src/web/assets/src/js/default-monaco-editor-options.ts #}
                 {% set options = {
+                    language: 'javascript',
+                    theme: 'vs',
                     lineNumbers: 'on',
                     lineNumbersMinChars: 4,
                     lineDecorationsWidth: 6,
                     folding: true,
                 } %}
-                {{ twigfield.textarea({
+                {{ codeEditor.textarea({
                     id: 'input',
                     class: 'hidden',
                     value: playground.component ?? '',

--- a/src/templates/index.twig
+++ b/src/templates/index.twig
@@ -120,17 +120,18 @@
             <div class="pane input-pane">
                 <p class="light code">{{ 'Component'|t('sprig') }}</p>
                 {# See default options in https://github.com/nystudio107/craft-code-editor/blob/develop/src/web/assets/src/js/default-monaco-editor-options.ts #}
-                {% set options = {
+                {% set monacoOptions = {
                     lineNumbers: 'on',
                     lineNumbersMinChars: 4,
                     lineDecorationsWidth: 6,
                     folding: true,
                 } %}
+                {% set codeEditorOptions = {} %}
                 {{ codeEditor.textarea({
                     id: 'input',
                     class: 'hidden',
                     value: playground.component ?? '',
-                }, 'SprigField', '', options) }}
+                }, 'SprigField', monacoOptions, codeEditorOptions) }}
                 <button id="create" type="submit" class="btn submit topright">{{ 'Create'|t('sprig') }}</button>
             </div>
         </div>


### PR DESCRIPTION
This PR updates Sprig to use [Code Editor](https://github.com/nystudio107/craft-code-editor) rather than Twigfield (which has been deprecated). Code Editor is a general-purpose code editor that _also_ does Twig & autocomplete.

Code Editor also has been refactored to TypeScript, supports light/dark themes, and has a tweaked/improved API.