### PR TITLE
Fix deprecation errors

### DIFF
--- a/src/templates/index.twig
+++ b/src/templates/index.twig
@@ -157,8 +157,6 @@
         </div>
     </div>
 
-    {{ sprig.script }}
-
     {% js %}
         let resourcesUrl = '{{ resourcesUrl }}';
     {% endjs %}


### PR DESCRIPTION
`sprig.script` has been deprecated. It is no longer required and can be safely removed.

PS. I can tell you're not working on this with `plugindev` ;) 