### PR TITLE
Run code analysis automatically via GitHub Action

### DIFF
--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -1,0 +1,40 @@
+name: Code Analysis
+
+on:
+  pull_request: null
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  code_analysis:
+    strategy:
+      fail-fast: false
+      matrix:
+        actions:
+          - name: 'PHPStan'
+            run: composer phpstan
+          - name: 'Coding Standards'
+            run: composer fix-cs
+    name: ${{ matrix.actions.name }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: /tmp/composer-cache
+          key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
+      - name: Setup PHP
+        id: setup-php
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          extensions: 'ctype,curl,dom,iconv,imagick,intl,json,mbstring,openssl,pcre,pdo,reflection,spl,zip'
+          ini-values: post_max_size=256M, max_execution_time=180, memory_limit=512M
+          tools: composer:v2
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --no-ansi --no-progress
+      - run: ${{ matrix.actions.run }}

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -31,7 +31,7 @@ jobs:
         id: setup-php
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.1
           extensions: 'ctype,curl,dom,iconv,imagick,intl,json,mbstring,openssl,pcre,pdo,reflection,spl,zip'
           ini-values: post_max_size=256M, max_execution_time=180, memory_limit=512M
           tools: composer:v2

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -18,6 +18,10 @@ jobs:
             run: composer phpstan
           - name: 'Coding Standards'
             run: composer fix-cs
+    # Tests could be run here too, just set the environment variables as needed, see:
+    # https://docs.github.com/en/actions/learn-github-actions/variables
+    #          - name: 'Tests'
+    #            run: composer test
     name: ${{ matrix.actions.name }}
     runs-on: ubuntu-latest
     steps:

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,15 @@
     "nystudio107/craft-code-editor": "^1.0.0",
     "putyourlightson/craft-sprig-core": "^2.6.4"
   },
+  "require-dev": {
+    "craftcms/ecs": "dev-main",
+    "craftcms/phpstan": "dev-main"
+  },
+  "scripts": {
+    "phpstan": "phpstan --ansi --memory-limit=1G",
+    "check-cs": "ecs check --ansi",
+    "fix-cs": "ecs check --fix --ansi",
+  },
   "autoload": {
     "psr-4": {
       "putyourlightson\\sprig\\plugin\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,20 @@
   "scripts": {
     "phpstan": "phpstan --ansi --memory-limit=1G",
     "check-cs": "ecs check --ansi",
-    "fix-cs": "ecs check --fix --ansi",
+    "fix-cs": "ecs check --fix --ansi"
   },
   "autoload": {
     "psr-4": {
       "putyourlightson\\sprig\\plugin\\": "src/"
     }
+  },
+  "config": {
+    "allow-plugins": {
+      "craftcms/plugin-installer": true,
+      "yiisoft/yii2-composer": true
+    },
+    "optimize-autoloader": true,
+    "sort-packages": true
   },
   "support": {
     "docs": "https://putyourlightson.com/plugins/sprig",

--- a/ecs.php
+++ b/ecs.php
@@ -4,11 +4,10 @@ use craft\ecs\SetList;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 return static function(ECSConfig $ecsConfig): void {
-    $ecsConfig->parallel();
     $ecsConfig->paths([
         __DIR__ . '/src',
         __FILE__,
     ]);
-
+    $ecsConfig->parallel();
     $ecsConfig->sets([SetList::CRAFT_CMS_4]);
 };

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 includes:
-    - %currentWorkingDirectory%/vendor/craftcms/phpstan/phpstan.neon
+    - vendor/craftcms/phpstan/phpstan.neon
+
 parameters:
     level: 5
     paths:


### PR DESCRIPTION
Added a GitHub Action that will automatically run `phpstan` and `ecs` code quality tools on pushes to the `develop` branch.

This likely could easily be extended to run unit tests on pushes as well (see the notes in the `.github/workflows/code-analysis.yaml` file)

It should be a simple copy pasta to add this to your other plugins, but that's left as an exercise for the reader